### PR TITLE
Indirect precode through slot

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1151,7 +1151,11 @@ class ICorCompilePreloader
 
     virtual DWORD MapModuleIDHandle(
             CORINFO_MODULE_HANDLE handle
-            )  = 0;
+            ) = 0;
+
+    virtual DWORD MapMethodSlot(
+            CORINFO_METHOD_HANDLE handle
+            ) = 0;
 
     // Load a method for the specified method def
     // If the class or method is generic, instantiate all parameters with <object>

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -1125,7 +1125,7 @@ class ICorCompilePreloader
     // Else, use ICorCompileInfo::CanEmbedXXX()
     //
 
-    virtual DWORD MapMethodEntryPoint(
+    virtual DWORD MapMethodSlot(
             CORINFO_METHOD_HANDLE handle
             ) = 0;
 
@@ -1151,10 +1151,6 @@ class ICorCompilePreloader
 
     virtual DWORD MapModuleIDHandle(
             CORINFO_MODULE_HANDLE handle
-            ) = 0;
-
-    virtual DWORD MapMethodSlot(
-            CORINFO_METHOD_HANDLE handle
             ) = 0;
 
     // Load a method for the specified method def

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -850,7 +850,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     // Set the actual chunk index
     FixupPrecode * pNewPrecode = (FixupPrecode *)image->GetImagePointer(this);
 
-    size_t mdOffset   = mdChunkOffset - sizeof(MethodDescChunk);
+    size_t mdOffset   = mdChunkOffset - MethodDescChunk::OffsetOfMethodDescsInSavedNode;
     size_t chunkIndex = mdOffset / MethodDesc::ALIGNMENT;
     _ASSERTE(FitsInU1(chunkIndex));
     pNewPrecode->m_MethodDescChunkIndex = (BYTE) chunkIndex;
@@ -859,7 +859,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     if (m_PrecodeChunkIndex == 0)
     {
         image->FixupFieldToNode(this, (BYTE *)GetBase() - (BYTE *)this,
-            pMDChunkNode, sizeof(MethodDescChunk));
+            pMDChunkNode, MethodDescChunk::OffsetOfMethodDescsInSavedNode);
     }
 }
 #endif // FEATURE_NATIVE_IMAGE_GENERATION

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -698,7 +698,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     // Set the actual chunk index
     FixupPrecode * pNewPrecode = (FixupPrecode *)image->GetImagePointer(this);
 
-    size_t mdOffset = mdChunkOffset - sizeof(MethodDescChunk);
+    size_t mdOffset = mdChunkOffset - MethodDescChunk::OffsetOfMethodDescsInSavedNode;
     size_t chunkIndex = mdOffset / MethodDesc::ALIGNMENT;
     _ASSERTE(FitsInU1(chunkIndex));
     pNewPrecode->m_MethodDescChunkIndex = (BYTE)chunkIndex;
@@ -707,7 +707,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     if (m_PrecodeChunkIndex == 0)
     {
         image->FixupFieldToNode(this, (BYTE *)GetBase() - (BYTE *)this,
-            pMDChunkNode, sizeof(MethodDescChunk));
+            pMDChunkNode, MethodDescChunk::OffsetOfMethodDescsInSavedNode);
     }
 }
 #endif // FEATURE_NATIVE_IMAGE_GENERATION

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3009,7 +3009,7 @@ void EEClass::Save(DataImage *image, MethodTable *pMT)
             methodDescSaveChunk.Append(pMD);
         }
 
-        ZapStoredStructure * pChunksNode = methodDescSaveChunk.Save();
+        ZapNode * pChunksNode = methodDescSaveChunk.Save();
         if (pChunksNode != NULL)    
             image->BindPointer(chunk, pChunksNode, 0);
 

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3009,9 +3009,9 @@ void EEClass::Save(DataImage *image, MethodTable *pMT)
             methodDescSaveChunk.Append(pMD);
         }
 
-        ZapNode * pChunksNode = methodDescSaveChunk.Save();
+        ZapStoredStructure * pChunksNode = methodDescSaveChunk.Save();
         if (pChunksNode != NULL)    
-            image->BindPointer(chunk, pChunksNode, 0);
+            image->BindPointer(chunk, pChunksNode, MethodDescChunk::OffsetInSavedNode);
 
     }
 

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -4708,6 +4708,14 @@ DWORD CEEPreloader::MapModuleIDHandle(CORINFO_MODULE_HANDLE handle)
     return m_image->GetRVA(handle) + (DWORD)Module::GetOffsetOfModuleID();
 }
 
+DWORD CEEPreloader::MapMethodSlot(CORINFO_METHOD_HANDLE handle)
+{
+    STANDARD_VM_CONTRACT;
+
+    MethodDesc *pMD = GetMethod(handle);
+    return m_image->GetRVA((PVOID)pMD->GetAddrOfSlot());
+}
+
 CORINFO_METHOD_HANDLE CEEPreloader::NextUncompiledMethod()
 {
     STANDARD_VM_CONTRACT;

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -4647,14 +4647,12 @@ void CEEPreloader::Preload(CorProfileData * profileData)
 // ICorCompilerPreloader
 //
 
-DWORD CEEPreloader::MapMethodEntryPoint(CORINFO_METHOD_HANDLE handle)
+DWORD CEEPreloader::MapMethodSlot(CORINFO_METHOD_HANDLE handle)
 {
     STANDARD_VM_CONTRACT;
 
     MethodDesc *pMD = GetMethod(handle);
-    Precode * pPrecode = pMD->GetSavedPrecode(m_image);
-
-    return m_image->GetRVA(pPrecode);
+    return m_image->GetRVA((PVOID)pMD->GetAddrOfSlot());
 }
 
 DWORD CEEPreloader::MapClassHandle(CORINFO_CLASS_HANDLE handle)
@@ -4706,14 +4704,6 @@ DWORD CEEPreloader::MapModuleIDHandle(CORINFO_MODULE_HANDLE handle)
     STANDARD_VM_CONTRACT;
 
     return m_image->GetRVA(handle) + (DWORD)Module::GetOffsetOfModuleID();
-}
-
-DWORD CEEPreloader::MapMethodSlot(CORINFO_METHOD_HANDLE handle)
-{
-    STANDARD_VM_CONTRACT;
-
-    MethodDesc *pMD = GetMethod(handle);
-    return m_image->GetRVA((PVOID)pMD->GetAddrOfSlot());
 }
 
 CORINFO_METHOD_HANDLE CEEPreloader::NextUncompiledMethod()

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -556,6 +556,7 @@ class CEEPreloader : public ICorCompilePreloader
     DWORD MapAddressOfPInvokeFixup(CORINFO_METHOD_HANDLE handle);
     DWORD MapGenericHandle(CORINFO_GENERIC_HANDLE handle);    
     DWORD MapModuleIDHandle(CORINFO_MODULE_HANDLE handle);
+    DWORD MapMethodSlot(CORINFO_METHOD_HANDLE handle);
 
     void AddMethodToTransitiveClosureOfInstantiations(CORINFO_METHOD_HANDLE handle);
     void AddTypeToTransitiveClosureOfInstantiations(CORINFO_CLASS_HANDLE handle);

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -549,14 +549,13 @@ class CEEPreloader : public ICorCompilePreloader
     // ICorCompilerPreloader
     //
 
-    DWORD MapMethodEntryPoint(CORINFO_METHOD_HANDLE handle);
+    DWORD MapMethodSlot(CORINFO_METHOD_HANDLE handle);
     DWORD MapClassHandle(CORINFO_CLASS_HANDLE handle);
     DWORD MapMethodHandle(CORINFO_METHOD_HANDLE handle);
     DWORD MapFieldHandle(CORINFO_FIELD_HANDLE handle);
     DWORD MapAddressOfPInvokeFixup(CORINFO_METHOD_HANDLE handle);
     DWORD MapGenericHandle(CORINFO_GENERIC_HANDLE handle);    
     DWORD MapModuleIDHandle(CORINFO_MODULE_HANDLE handle);
-    DWORD MapMethodSlot(CORINFO_METHOD_HANDLE handle);
 
     void AddMethodToTransitiveClosureOfInstantiations(CORINFO_METHOD_HANDLE handle);
     void AddTypeToTransitiveClosureOfInstantiations(CORINFO_CLASS_HANDLE handle);

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -714,6 +714,7 @@ FORCEINLINE static CorCompileSection GetSectionForNodeType(ZapNodeType type)
         return CORCOMPILE_SECTION_READONLY_HOT;
 
     // SECTION_HOT_WRITEABLE
+    case NodeTypeForItemKind(DataImage::ITEM_METHOD_TABLE):
     case NodeTypeForItemKind(DataImage::ITEM_METHOD_DESC_HOT_WRITEABLE):
     case NodeTypeForItemKind(DataImage::ITEM_METHOD_TABLE_DATA_HOT_WRITEABLE):
     case NodeTypeForItemKind(DataImage::ITEM_NGEN_HASH_HOT):
@@ -737,7 +738,6 @@ FORCEINLINE static CorCompileSection GetSectionForNodeType(ZapNodeType type)
         return CORCOMPILE_SECTION_WARM;
 
     // SECTION_READONLY_WARM
-    case NodeTypeForItemKind(DataImage::ITEM_METHOD_TABLE):
     case NodeTypeForItemKind(DataImage::ITEM_INTERFACE_MAP):
     case NodeTypeForItemKind(DataImage::ITEM_DISPATCH_MAP):
     case NodeTypeForItemKind(DataImage::ITEM_GENERICS_STATIC_FIELDDESCS):

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -25,7 +25,6 @@
 #include "../zap/zapwriter.h"
 #include "../zap/zapimage.h"
 #include "../zap/zapimport.h"
-#include "../zap/zapinnerptr.h"
 #include "inlinetracking.h"
 
 #define NodeTypeForItemKind(kind) ((ZapNodeType)(ZapNodeType_StoredStructure + kind))
@@ -288,11 +287,6 @@ void DataImage::CopyDataToOffset(ZapStoredStructure * pNode, ULONG offset, const
     memcpy((void *) target, p, size);
 }
 
-ZapNode * DataImage::GetInnerPtr(ZapNode * pNode, SSIZE_T offset)
-{
-    return m_pZapImage->GetInnerPtr(pNode, offset);
-}
-
 void DataImage::PlaceStructureForAddress(const void * data, CorCompileSection section)
 {
     STANDARD_VM_CONTRACT;
@@ -419,17 +413,6 @@ static SSIZE_T DecodeTargetOffset(PVOID pLocation, ZapRelocationType type)
     }
 }
 
-static void UnwrapInnerPtr(ZapNode ** ppNode, SSIZE_T * pOffset)
-{
-    ZapNode * pNode = *ppNode;
-    if (pNode->GetType() == ZapNodeType_InnerPtr)
-    {
-        ZapInnerPtr * pInnerPtr = (ZapInnerPtr *)pNode;
-        *ppNode = pInnerPtr->GetBase();
-        *pOffset += pInnerPtr->GetOffset();
-    }
-}
-
 void DataImage::FixupField(PVOID p, SSIZE_T offset, PVOID pTarget, SSIZE_T targetOffset, ZapRelocationType type)
 {
     STANDARD_VM_CONTRACT;
@@ -458,18 +441,14 @@ void DataImage::FixupField(PVOID p, SSIZE_T offset, PVOID pTarget, SSIZE_T targe
     targetOffset += pTargetEntry->offset;
     _ASSERTE(0 <= targetOffset && (DWORD)targetOffset <= pTargetEntry->pNode->GetSize());
 
-    SSIZE_T finalOffset = offset;
-    ZapNode * pNode = pEntry->pNode;
-    UnwrapInnerPtr(&pNode, &finalOffset);
-
     FixupEntry entry;
     entry.m_type = type;
-    entry.m_offset = (DWORD)finalOffset;
-    entry.m_pLocation = AsStoredStructure(pNode);
+    entry.m_offset = (DWORD)offset;
+    entry.m_pLocation = AsStoredStructure(pEntry->pNode);
     entry.m_pTargetNode = pTargetEntry->pNode;
     AppendFixup(entry);
 
-    EncodeTargetOffset((BYTE *)AsStoredStructure(pNode)->GetData() + finalOffset, targetOffset, type);
+    EncodeTargetOffset((BYTE *)AsStoredStructure(pEntry->pNode)->GetData() + offset, targetOffset, type);
 }
 
 void DataImage::FixupFieldToNode(PVOID p, SSIZE_T offset, ZapNode * pTarget, SSIZE_T targetOffset, ZapRelocationType type)
@@ -491,18 +470,14 @@ void DataImage::FixupFieldToNode(PVOID p, SSIZE_T offset, ZapNode * pTarget, SSI
 
     _ASSERTE(pTarget != NULL);
 
-    SSIZE_T finalOffset = offset;
-    ZapNode * pNode = pEntry->pNode;
-    UnwrapInnerPtr(&pNode, &finalOffset);
-
     FixupEntry entry;
     entry.m_type = type;
-    entry.m_offset = (DWORD)finalOffset;
-    entry.m_pLocation = AsStoredStructure(pNode);
+    entry.m_offset = (DWORD)offset;
+    entry.m_pLocation = AsStoredStructure(pEntry->pNode);
     entry.m_pTargetNode = pTarget;
     AppendFixup(entry);
 
-    EncodeTargetOffset((BYTE *)AsStoredStructure(pNode)->GetData() + finalOffset, targetOffset, type);
+    EncodeTargetOffset((BYTE *)AsStoredStructure(pEntry->pNode)->GetData() + offset, targetOffset, type);
 }
 
 DWORD DataImage::GetRVA(const void *data)
@@ -512,17 +487,7 @@ DWORD DataImage::GetRVA(const void *data)
     const StructureEntry * pEntry = m_structures.LookupPtr(data);
     _ASSERTE(pEntry != NULL);
 
-    ZapNode * pNode = pEntry->pNode;
-    SSIZE_T offset = pEntry->offset;
-
-    // Solve a problem with ordering of ComputeRVA.
-    // If there's a normal node which needs innerptr node's RVA it will likely fail
-    // since the innerptrs are resolved last.
-    // On the other hand, if the base of the innerptr is already resolved, then the innerptr's
-    // RVA can always be computed.
-    UnwrapInnerPtr(&pNode, &offset);
-
-    return pNode->GetRVA() + (DWORD)offset;
+    return pEntry->pNode->GetRVA() + (DWORD)pEntry->offset;
 }
 
 void DataImage::ZeroField(PVOID p, SSIZE_T offset, SIZE_T size)
@@ -552,11 +517,7 @@ void * DataImage::GetImagePointer(PVOID p, SSIZE_T offset)
     offset += pEntry->offset;
     _ASSERTE(0 <= offset && (DWORD)offset < pEntry->pNode->GetSize());
 
-    SSIZE_T finalOffset = offset;
-    ZapNode * pNode = pEntry->pNode;
-    UnwrapInnerPtr(&pNode, &finalOffset);
-
-    return (BYTE *)AsStoredStructure(pNode)->GetData() + finalOffset;
+    return (BYTE *)AsStoredStructure(pEntry->pNode)->GetData() + offset;
 }
 
 ZapNode * DataImage::GetNodeForStructure(PVOID p, SSIZE_T * pOffset)

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -1268,18 +1268,18 @@ class ZapStubPrecodeChunk : public ZapNode
 protected:
     MethodDesc ** m_ppMD;
     COUNT_T m_count;
-    SSIZE_T m_sizeOfOne;
+    SIZE_T m_sizeOfOne;
     DataImage::ItemKind m_kind;
 
 public:
-    ZapStubPrecodeChunk(MethodDesc ** ppMethod, COUNT_T count, SSIZE_T sizeOfOne, DataImage::ItemKind kind)
+    ZapStubPrecodeChunk(MethodDesc ** ppMethod, COUNT_T count, SIZE_T sizeOfOne, DataImage::ItemKind kind)
         : m_ppMD(ppMethod), m_count(count), m_sizeOfOne(sizeOfOne), m_kind(kind)
     {
     }
 
     virtual DWORD GetSize()
     {
-        return m_count * m_sizeOfOne;
+        return (DWORD)(m_count * m_sizeOfOne);
     }
 
     virtual UINT GetAlignment()
@@ -1318,7 +1318,7 @@ public:
     virtual void Save(ZapWriter * pZapWriter)
     {
         ZapImage * pImage = ZapImage::GetImage(pZapWriter);
-        SSIZE_T size = m_count * m_sizeOfOne;
+        SIZE_T size = m_count * m_sizeOfOne;
         TADDR pBase = (TADDR)new (pImage->GetHeap()) BYTE[size];
 
         for (COUNT_T i = 0; i < m_count; i++)
@@ -1337,16 +1337,16 @@ public:
                 pImage->GetHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
         }
 
-        pZapWriter->Write(PVOID(pBase), size);
+        pZapWriter->Write(PVOID(pBase), (DWORD)size);
     }
 };
 
-void DataImage::SaveStubPrecodeChunk(TADDR ptr, SSIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind)
+void DataImage::SaveStubPrecodeChunk(TADDR ptr, SIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind)
 {
     MethodDesc ** ppMDCopy = (MethodDesc **) new (GetHeap()) BYTE[sizeof(MethodDesc *) * count];
     ZapStubPrecodeChunk * pNode = new (GetHeap()) ZapStubPrecodeChunk(ppMDCopy, count, sizeOfOne, kind);
 
-    SSIZE_T offset = 0;
+    SIZE_T offset = 0;
     for (COUNT_T i = 0; i < count; i++)
     {
         ppMDCopy[i] = ppMD[i];

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -463,7 +463,7 @@ public:
 
     ZapNode * GetGenericSignature(PVOID signature, BOOL fMethod);
 
-    void SaveStubPrecodeChunk(TADDR ptr, SSIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind);
+    void SaveStubPrecodeChunk(TADDR ptr, SIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind);
 #ifdef HAS_NDIRECT_IMPORT_PRECODE
     void SaveNDirectPrecode(PVOID ptr, MethodDesc * pMD, ItemKind kind);
 #endif // HAS_NDIRECT_IMPORT_PRECODE

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -470,7 +470,9 @@ public:
     ZapNode * GetGenericSignature(PVOID signature, BOOL fMethod);
 
     void SaveStubPrecodeChunk(TADDR ptr, SSIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind);
-    void SavePrecode(PVOID ptr, MethodDesc * pMD, PrecodeType t, ItemKind kind, BOOL fIsPrebound = FALSE);
+#ifdef HAS_NDIRECT_IMPORT_PRECODE
+    void SaveNDirectPrecode(PVOID ptr, MethodDesc * pMD, ItemKind kind);
+#endif // HAS_NDIRECT_IMPORT_PRECODE
 
     void StoreCompressedLayoutMap(LookupMapBase *pMap, ItemKind kind);
 

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -285,6 +285,12 @@ public:
     void CopyData(ZapStoredStructure * pNode, const void * p, ULONG size);
     void CopyDataToOffset(ZapStoredStructure * pNode, ULONG offset, const void * p, ULONG size);
 
+    ZapNode * GetInnerPtr(ZapNode * pNode, SSIZE_T offset);
+    ZapNode * GetInnerPtr(ZapStoredStructure * pNode, SSIZE_T offset)
+    {
+        return GetInnerPtr((ZapNode *)pNode, offset);
+    }
+
     //
     // In the second phase, data is arranged in the image by successive calls
     // to PlaceMappedRange.  Items are arranged using pointers to data structures in the

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -469,6 +469,7 @@ public:
 
     ZapNode * GetGenericSignature(PVOID signature, BOOL fMethod);
 
+    void SaveStubPrecodeChunk(TADDR ptr, SSIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind);
     void SavePrecode(PVOID ptr, MethodDesc * pMD, PrecodeType t, ItemKind kind, BOOL fIsPrebound = FALSE);
 
     void StoreCompressedLayoutMap(LookupMapBase *pMap, ItemKind kind);

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -285,12 +285,6 @@ public:
     void CopyData(ZapStoredStructure * pNode, const void * p, ULONG size);
     void CopyDataToOffset(ZapStoredStructure * pNode, ULONG offset, const void * p, ULONG size);
 
-    ZapNode * GetInnerPtr(ZapNode * pNode, SSIZE_T offset);
-    ZapNode * GetInnerPtr(ZapStoredStructure * pNode, SSIZE_T offset)
-    {
-        return GetInnerPtr((ZapNode *)pNode, offset);
-    }
-
     //
     // In the second phase, data is arranged in the image by successive calls
     // to PlaceMappedRange.  Items are arranged using pointers to data structures in the

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -6701,7 +6701,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     // Set the actual chunk index
     FixupPrecode * pNewPrecode = (FixupPrecode *)image->GetImagePointer(this);
 
-    size_t mdOffset   = mdChunkOffset - sizeof(MethodDescChunk);
+    size_t mdOffset   = mdChunkOffset - MethodDescChunk::OffsetOfMethodDescsInSavedNode;
     size_t chunkIndex = mdOffset / MethodDesc::ALIGNMENT;
     _ASSERTE(FitsInU1(chunkIndex));
     pNewPrecode->m_MethodDescChunkIndex = (BYTE) chunkIndex;
@@ -6710,7 +6710,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     if (m_PrecodeChunkIndex == 0)
     {
         image->FixupFieldToNode(this, (BYTE *)GetBase() - (BYTE *)this,
-            pMDChunkNode, sizeof(MethodDescChunk));
+            pMDChunkNode, MethodDescChunk::OffsetOfMethodDescsInSavedNode);
     }
 }
 #endif // FEATURE_NATIVE_IMAGE_GENERATION

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -4820,7 +4820,7 @@ Precode* MethodDesc::GetOrCreatePrecode()
         // If the method is zapped, then the only way it may not have a stable entry point yet
         // is that it has a precode. In this case it's not marked as having precode through HasPrecode
         // instead the zapped precode acts as a temporary entry point.
-        pExpected = *pSlot;
+        pExpected = ::VolatileLoadWithoutBarrier(pSlot);
         Module * pZapModule = GetZapModule();
         if ((pZapModule == NULL) || !pZapModule->IsZappedPrecode(pExpected))
         {
@@ -4921,7 +4921,7 @@ BOOL MethodDesc::SetStableEntryPointInterlocked(PCODE addr, PTR_PCODE ppPrevious
     {
         // If the method is zapped, then the only way it may not have a stable entry point yet
         // is that it has a precode.
-        pExpected = *pSlot;
+        pExpected = ::VolatileLoadWithoutBarrier(pSlot);
         Module * pZapModule = GetZapModule();
         if ((pZapModule == NULL) || !pZapModule->IsZappedPrecode(pExpected))
         {

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -4885,7 +4885,7 @@ BOOL MethodDesc::SetNativeCodeInterlocked(PCODE addr, PCODE pExpected /*=NULL*/)
 }
 
 //*******************************************************************************
-BOOL MethodDesc::SetStableEntryPointInterlocked(PCODE addr)
+BOOL MethodDesc::SetStableEntryPointInterlocked(PCODE addr, PTR_PCODE ppPreviousEntryPoint /*=NULL*/)
 {
     CONTRACTL {
         THROWS;
@@ -4909,6 +4909,11 @@ BOOL MethodDesc::SetStableEntryPointInterlocked(PCODE addr)
     else
     {
         pExpected = GetTemporaryEntryPoint();
+    }
+
+    if (ppPreviousEntryPoint != NULL)
+    {
+        *ppPreviousEntryPoint = pExpected;
     }
 
     EnsureWritablePages(pSlot);

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -4826,7 +4826,7 @@ Precode* MethodDesc::GetOrCreatePrecode()
         {
             // This should really only happen if there is a race between two threads calling GetOrCreatePrecode at the same time.
             // In that case the slot should either contain the zapped precode, or the newly allocated runtime precode.
-            // So try to "reuse" the precode - this should always suceed, since we should not need a differe precode type.
+            // So try to "reuse" the runtime allocated precode - this should always succeed, since we should not need a different precode type.
             availableType = Precode::GetPrecodeFromEntryPoint(pExpected)->GetType();
         }
 

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -2702,7 +2702,7 @@ void MethodDesc::Save(DataImage *image)
         {
             // import thunk is only needed if the P/Invoke is inlinable
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)  
-            image->SavePrecode(pNMD->GetNDirectImportThunkGlue(), pNMD, PRECODE_NDIRECT_IMPORT, DataImage::ITEM_METHOD_PRECODE_COLD);
+            image->SaveNDirectPrecode(pNMD->GetNDirectImportThunkGlue(), pNMD, DataImage::ITEM_METHOD_PRECODE_COLD);
 #else
             image->StoreStructure(pNMD->GetNDirectImportThunkGlue(), sizeof(NDirectImportThunkGlue), DataImage::ITEM_METHOD_PRECODE_COLD);
 #endif

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -250,7 +250,7 @@ public:
         return GetMethodEntryPoint();
     }
 
-    BOOL SetStableEntryPointInterlocked(PCODE addr);
+    BOOL SetStableEntryPointInterlocked(PCODE addr, PTR_PCODE ppPreviousEntryPoint = NULL);
 
     BOOL HasTemporaryEntryPoint();
     PCODE GetTemporaryEntryPoint();
@@ -1635,11 +1635,13 @@ public:
     //     pDispatchingMT - method table of the object that the method is being dispatched on, can be NULL.
     //     fFullBackPatch - indicates whether to patch all possible slots, including the ones 
     //                      expensive to patch
+    //     pPreviousEntryPoint - if this is not NULL, the value is used as the expected value for all the patching
+    //                           that is slots with this value will be patched.
     //                      
     // Return value:
     //     stable entry point (code:MethodDesc::GetStableEntryPoint())
     //
-    PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch);
+    PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch, PCODE pPreviousEntryPoint);
 
     PCODE DoPrestub(MethodTable *pDispatchingMT);
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -250,7 +250,7 @@ public:
         return GetMethodEntryPoint();
     }
 
-    BOOL SetStableEntryPointInterlocked(PCODE addr, PTR_PCODE ppPreviousEntryPoint = NULL);
+    BOOL SetStableEntryPointInterlocked(PCODE addr);
 
     BOOL HasTemporaryEntryPoint();
     PCODE GetTemporaryEntryPoint();
@@ -1635,13 +1635,11 @@ public:
     //     pDispatchingMT - method table of the object that the method is being dispatched on, can be NULL.
     //     fFullBackPatch - indicates whether to patch all possible slots, including the ones 
     //                      expensive to patch
-    //     pPreviousEntryPoint - if this is not NULL, the value is used as the expected value for all the patching
-    //                           that is slots with this value will be patched.
     //                      
     // Return value:
     //     stable entry point (code:MethodDesc::GetStableEntryPoint())
     //
-    PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch, PCODE pPreviousEntryPoint);
+    PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch);
 
     PCODE DoPrestub(MethodTable *pDispatchingMT);
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1966,15 +1966,20 @@ public:
     BOOL HasTemporaryEntryPoints()
     {
         LIMITED_METHOD_CONTRACT;
-        return !IsZapped();
+        return GetTemporaryEntryPoints() != NULL;
+    }
+
+    TADDR GetTemporaryEntryPointsSlot()
+    {
+        LIMITED_METHOD_CONTRACT;
+        _ASSERTE(sizeof(TADDR) == sizeof(TemporaryEntryPointsSlot));
+        return dac_cast<TADDR>(this) - sizeof(TADDR);
     }
 
     TADDR GetTemporaryEntryPoints()
     {
         LIMITED_METHOD_CONTRACT;
-        _ASSERTE(HasTemporaryEntryPoints());
-        _ASSERTE(sizeof(TADDR) == sizeof(TemporaryEntryPointsSlot));
-        TADDR pSlot = dac_cast<TADDR>(this) - sizeof(TADDR);
+        TADDR pSlot = GetTemporaryEntryPointsSlot();
         return IsZapped() ? TemporaryEntryPointsSlot::GetValueAtPtr(pSlot) : *PTR_TADDR(pSlot);
     }
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1534,7 +1534,7 @@ public:
     {
         DataImage * m_pImage;
 
-        ZapNode * m_pFirstNode;
+        ZapStoredStructure * m_pFirstNode;
         MethodDescChunk * m_pLastChunk;
 
         typedef enum _MethodPriorityEnum
@@ -1575,7 +1575,7 @@ public:
 
         void Append(MethodDesc * pMD);
 
-        ZapNode * Save();
+        ZapStoredStructure * Save();
     };
 
     bool CanSkipDoPrestub(MethodDesc * callerMD, 
@@ -2132,6 +2132,11 @@ public:
     // The chunk is preceded by a temporary entry point slot.
     // For zapped chunks the slot is a relative pointer, for non-zapped it's a direct address.
     typedef RelativePointer<TADDR> TemporaryEntryPointsSlot;
+
+    // The offset of the MethodDescChunk structure in the node where it's saved (since it doesn't start at 0).
+    static const ULONG OffsetInSavedNode = sizeof(TemporaryEntryPointsSlot);
+    // The offset where the MethodDesc array starts in the saved node.
+    static const ULONG OffsetOfMethodDescsInSavedNode;
 
     // Maximum size of one chunk (corresponts to the maximum of m_size = 0xFF)
     static const SIZE_T MaxSizeOfMethodDescs = 0x100 * MethodDesc::ALIGNMENT;

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -86,19 +86,7 @@ BOOL Precode::IsZapped()
     SUPPORTS_DAC;
 
 #ifdef FEATURE_PREJIT
-    return IsZapped((PTR_MethodDesc)GetMethodDesc());
-#else
-    return FALSE;
-#endif
-}
-
-BOOL Precode::IsZapped(PTR_MethodDesc pMD)
-{
-    LIMITED_METHOD_CONTRACT;
-    SUPPORTS_DAC;
-
-#ifdef FEATURE_PREJIT
-    _ASSERTE(pMD == GetMethodDesc());
+    PTR_MethodDesc pMD = (PTR_MethodDesc)GetMethodDesc();
     Module * pZapModule = pMD->GetZapModule();
     return (pZapModule != NULL) && pZapModule->IsZappedPrecode((PCODE)this);
 #else
@@ -115,17 +103,13 @@ PCODE Precode::GetTarget()
     PCODE target = NULL;
 
     PrecodeType precodeType = GetType();
-#ifdef FEATURE_PREJIT
-    PTR_MethodDesc pMD;
-#endif
     switch (precodeType)
     {
     case PRECODE_STUB:
 #ifdef FEATURE_PREJIT
-        pMD = (PTR_MethodDesc)AsStubPrecode()->GetMethodDesc();
-        if (IsZapped(pMD))
+        if (IsZapped())
         {
-            target = pMD->GetMethodEntryPoint();
+            target = GetMethodDesc()->GetMethodEntryPoint();
             if (target != this->GetEntryPoint())
             {
                 break;
@@ -137,10 +121,9 @@ PCODE Precode::GetTarget()
 #ifdef HAS_REMOTING_PRECODE
     case PRECODE_REMOTING:
 #ifdef FEATURE_PREJIT
-        pMD = (PTR_MethodDesc)AsRemotingPrecode()->GetMethodDesc();
-        if (IsZapped(pMD))
+        if (IsZapped())
         {
-            target = pMD->GetMethodEntryPoint();
+            target = GetMethodDesc()->GetMethodEntryPoint();
             if (target != this->GetEntryPoint())
             {
                 break;
@@ -153,10 +136,9 @@ PCODE Precode::GetTarget()
 #ifdef HAS_FIXUP_PRECODE
     case PRECODE_FIXUP:
 #ifdef FEATURE_PREJIT
-        pMD = (PTR_MethodDesc)AsFixupPrecode()->GetMethodDesc();
-        if (IsZapped(pMD))
+        if (IsZapped())
         {
-            target = pMD->GetMethodEntryPoint();
+            target = GetMethodDesc()->GetMethodEntryPoint();
             if (target != this->GetEntryPoint())
             {
                 break;
@@ -546,17 +528,13 @@ BOOL Precode::SetTargetInterlocked(PCODE target, BOOL fOnlyRedirectFromPrestub)
     g_IBCLogger.LogMethodPrecodeWriteAccess(GetMethodDesc());
 
     PrecodeType precodeType = GetType();
-#ifdef FEATURE_PREJIT
-    PTR_MethodDesc pMD;
-#endif
     switch (precodeType)
     {
     case PRECODE_STUB:
 #ifdef FEATURE_PREJIT
-        pMD = (PTR_MethodDesc)AsStubPrecode()->GetMethodDesc();
-        if (IsZapped(pMD))
+        if (IsZapped())
         {
-            SetZappedTargetInterlocked(pMD, target, expected);
+            SetZappedTargetInterlocked(GetMethodDesc(), target, expected);
         }
         else
 #endif
@@ -584,10 +562,9 @@ BOOL Precode::SetTargetInterlocked(PCODE target, BOOL fOnlyRedirectFromPrestub)
 #ifdef HAS_FIXUP_PRECODE
     case PRECODE_FIXUP:
 #ifdef FEATURE_PREJIT
-        pMD = (PTR_MethodDesc)AsFixupPrecode()->GetMethodDesc();
-        if (IsZapped(pMD))
+        if (IsZapped())
         {
-            SetZappedTargetInterlocked(pMD, target, expected);
+            SetZappedTargetInterlocked(GetMethodDesc(), target, expected);
         }
         else
 #endif

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -98,6 +98,7 @@ BOOL Precode::IsZapped(PTR_MethodDesc pMD)
     SUPPORTS_DAC;
 
 #ifdef FEATURE_PREJIT
+    _ASSERTE(pMD == GetMethodDesc());
     Module * pZapModule = pMD->GetZapModule();
     return (pZapModule != NULL) && pZapModule->IsZappedPrecode((PCODE)this);
 #else

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -784,7 +784,7 @@ static PVOID SaveFixupPrecodeChunk(
 {
     STANDARD_VM_CONTRACT;
 
-    ULONG size = sizeof(FixupPrecode) * count + sizeof(PTR_MethodDesc);
+    SIZE_T size = sizeof(FixupPrecode) * count + sizeof(PTR_MethodDesc);
     FixupPrecode * pBase = (FixupPrecode *)new (image->GetHeap()) BYTE[size];
 
     ZapStoredStructure * pNode = image->StoreStructure(NULL, size, kind,
@@ -808,7 +808,7 @@ static PVOID SaveFixupPrecodeChunk(
             image->RegisterSurrogate(pMD, pPrecode);
     }
 
-    image->CopyData(pNode, pBase, size);
+    image->CopyData(pNode, pBase, (ULONG)size);
 
     return pBase;
 }
@@ -823,8 +823,8 @@ static PVOID SaveStubPrecodeChunk(
 {
     STANDARD_VM_CONTRACT;
 
-    ULONG sizeOfOne = Precode::SizeOfTemporaryEntryPoint(PRECODE_STUB);
-    ULONG size = sizeOfOne * count;
+    SIZE_T sizeOfOne = Precode::SizeOfTemporaryEntryPoint(PRECODE_STUB);
+    SIZE_T size = sizeOfOne * count;
     TADDR pBase = (TADDR)new (image->GetHeap()) BYTE[size];
 
     for (COUNT_T i = 0; i < count; i++)
@@ -852,7 +852,7 @@ static PVOID SaveStubPrecodeChunk(
         image->BindPointer((void *)(pBase + (sizeOfOne * i)), pNode, sizeOfOne * i);
     }
 
-    image->CopyData(pNode, (void *)pBase, size);
+    image->CopyData(pNode, (void *)pBase, (ULONG)size);
 #endif // defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
     return (PVOID)pBase;

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -796,31 +796,15 @@ BOOL Precode::IsPrebound(DataImage *image)
 #endif
 }
 
-void Precode::SaveChunk::Save(DataImage* image, MethodDesc * pMD)
+void Precode::SaveChunk::AddPrecodeForMethod(MethodDesc * pMD)
 {
     STANDARD_VM_CONTRACT;
 
-    PrecodeType precodeType = pMD->GetPrecodeType();
-
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
-    if (precodeType == PRECODE_FIXUP)
-    {
-        m_rgPendingChunk.Append(pMD);
-        return;
-    }
-#endif // HAS_FIXUP_PRECODE_CHUNKS
-
-    SIZE_T size = Precode::SizeOf(precodeType);
-    Precode* pPrecode = (Precode *)new (image->GetHeap()) BYTE[size];
-    pPrecode->Init(precodeType, pMD, NULL);
-    pPrecode->Save(image);
-
-    // Alias the temporary entrypoint
-    image->RegisterSurrogate(pMD, pPrecode);
+    m_rgPendingChunk.Append(pMD);
 }
 
 #ifdef HAS_FIXUP_PRECODE_CHUNKS
-static void SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T count, DataImage::ItemKind kind)
+static PVOID SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T count, DataImage::ItemKind kind)
 {
     STANDARD_VM_CONTRACT;
 
@@ -836,6 +820,7 @@ static void SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T
         FixupPrecode * pPrecode = pBase + i;
 
         pPrecode->InitForSave((count - 1) - i);
+        _ASSERTE((Precode *)pPrecode == Precode::GetPrecodeForTemporaryEntryPoint((TADDR)pBase, i));
 
         image->BindPointer(pPrecode, pNode, i * sizeof(FixupPrecode));
 
@@ -844,67 +829,69 @@ static void SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T
     }
 
     image->CopyData(pNode, pBase, size);
+
+    return pBase;
 }
 #endif // HAS_FIXUP_PRECODE_CHUNKS
 
-void Precode::SaveChunk::Flush(DataImage * image)
+static PVOID SaveStubPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T count, DataImage::ItemKind kind)
+{
+    ULONG sizeOfOne = Precode::SizeOfTemporaryEntryPoint(PRECODE_STUB);
+    ULONG size = sizeOfOne * count;
+    TADDR pBase = (TADDR)new (image->GetHeap()) BYTE[size];
+
+    for (COUNT_T i = 0; i < count; i++)
+    {
+        MethodDesc * pMD = rgMD[i];
+        StubPrecode * pPrecode = (StubPrecode *)(pBase + (sizeOfOne * i));
+
+        pPrecode->Init(pMD, NULL);
+        _ASSERTE((Precode *)pPrecode == Precode::GetPrecodeForTemporaryEntryPoint(pBase, i));
+
+        // Alias the temporary entrypoint
+        image->RegisterSurrogate(pMD, pPrecode);
+    }
+
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+    image->SaveStubPrecodeChunk(pBase, sizeOfOne, rgMD, count, kind);
+#else
+    ZapStoredStructure * pNode = image->StoreStructure(NULL, size, kind, PRECODE_ALIGNMENT);
+    for (COUNT_T i = 0; i < count; i++)
+    {
+        image->BindPointer((void *)(pBase + (sizeOfOne * i)), pNode, sizeOfOne * i);
+    }
+
+    image->CopyData(pNode, (void *)pBase, size);
+#endif // defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+
+    return (PVOID)pBase;
+}
+
+PVOID Precode::SaveChunk::Save(DataImage * image)
 {
     STANDARD_VM_CONTRACT;
 
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
+    // TODO: Since we have to save precodes in chunks defined by the MethodDescChunk
+    // and not by us here, the hot/cold splitting of precodes is not possible anymore
+    // Review the changes here and decide how to handle this - maybe we could apply the
+    // precode hot/cold split to method desc chunk ordering, or we will have to completely ignore it.
+    // For now we will save everything as cold - but that should probably change
+    // we should possibly apply the same hot/cold split as for methods themselves.
     if (m_rgPendingChunk.GetCount() == 0)
-        return;
+        return NULL;
 
-    // Sort MethodDescs using the item kind for hot-cold spliting
-    struct SortMethodDesc : CQuickSort< MethodDesc * >
-    {
-        DataImage * m_image;
-
-        SortMethodDesc(DataImage *image, MethodDesc **pBase, SSIZE_T iCount)
-            : CQuickSort< MethodDesc * >(pBase, iCount),
-            m_image(image)
-        {
-        }
-
-        int Compare(MethodDesc ** ppMD1, MethodDesc ** ppMD2)
-        {
-            MethodDesc * pMD1 = *ppMD1;
-            MethodDesc * pMD2 = *ppMD2;
-
-            // Compare item kind
-            DataImage::ItemKind kind1 = GetPrecodeItemKind(m_image, pMD1);
-            DataImage::ItemKind kind2 = GetPrecodeItemKind(m_image, pMD2);
-
-            return kind1 - kind2;
-        }
-    };
-
-    SortMethodDesc sort(image, &(m_rgPendingChunk[0]), m_rgPendingChunk.GetCount());
-    sort.Sort();
-
-    DataImage::ItemKind pendingKind = DataImage::ITEM_METHOD_PRECODE_COLD_WRITEABLE;
-    COUNT_T pendingCount = 0;
-
-    COUNT_T i;
-    for (i = 0; i < m_rgPendingChunk.GetCount(); i++)
-    {
-        MethodDesc * pMD = m_rgPendingChunk[i];
-
-        DataImage::ItemKind kind = GetPrecodeItemKind(image, pMD);
-        if (kind != pendingKind)
-        {
-            if (pendingCount != 0)
-                SaveFixupPrecodeChunk(image, &(m_rgPendingChunk[i-pendingCount]), pendingCount, pendingKind);
-
-            pendingKind = kind;
-            pendingCount = 0;
-        }
-
-        pendingCount++;
-    }
-
-    // Flush the remaining items
-    SaveFixupPrecodeChunk(image, &(m_rgPendingChunk[i-pendingCount]), pendingCount, pendingKind);
+    // The type of the precode used is simple.
+    // If we can, we will use Fixup precodes as those are more space efficient.
+    // If not we fallback to Stub precodes. We use the same precode type for all precodes in one chunk.
+    // There's no need to use precode which would be most suitable for the given method
+    // as the precodes saved here act as temporary entry points which will never be patched.
+    // Nobody should use the precode as a stable/multi-callable entry point for the method.
+    // We need the precode as the most simple way to get to the DoPrestub which will figure out
+    // what the method needs and potentially create a runtime allocated (patchable) precode of the right type.
+#ifdef HAS_FIXUP_PRECODE_CHUNKS
+    return SaveFixupPrecodeChunk(image, &m_rgPendingChunk[0], m_rgPendingChunk.GetCount(), DataImage::ItemKind::ITEM_METHOD_PRECODE_COLD);
+#else
+    return SaveStubPrecodeChunk(image, &m_rgPendingChunk[0], m_rgPendingChunk.GetCount(), DataImage::ItemKind::ITEM_METHOD_PRECODE_COLD);
 #endif // HAS_FIXUP_PRECODE_CHUNKS
 }
 

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -80,6 +80,31 @@ SIZE_T Precode::SizeOf(PrecodeType t)
     return 0;
 }
 
+BOOL Precode::IsZapped()
+{
+    LIMITED_METHOD_CONTRACT;
+    SUPPORTS_DAC;
+
+#ifdef FEATURE_PREJIT
+    return IsZapped((PTR_MethodDesc)GetMethodDesc());
+#else
+    return FALSE;
+#endif
+}
+
+BOOL Precode::IsZapped(PTR_MethodDesc pMD)
+{
+    LIMITED_METHOD_CONTRACT;
+    SUPPORTS_DAC;
+
+#ifdef FEATURE_PREJIT
+    Module * pZapModule = pMD->GetZapModule();
+    return (pZapModule != NULL) && pZapModule->IsZappedPrecode((PCODE)this);
+#else
+    return FALSE;
+#endif
+}
+
 // Note: This is immediate target of the precode. It does not follow jump stub if there is one.
 PCODE Precode::GetTarget()
 {

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -700,36 +700,6 @@ static DataImage::ItemKind GetPrecodeItemKind(DataImage * image, MethodDesc * pM
     return kind;
 }
 
-void Precode::Save(DataImage *image)
-{
-    STANDARD_VM_CONTRACT;
-
-    MethodDesc * pMD = GetMethodDesc();
-    PrecodeType t = GetType();
-
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
-    _ASSERTE(GetType() != PRECODE_FIXUP);
-#endif
-
-#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
-    // StubPrecode and RemotingPrecode may have straddlers (relocations crossing pages) on x86 and x64. We need 
-    // to insert padding to eliminate it. To do that, we need to save these using custom ZapNode that can only
-    // be implemented in dataimage.cpp or zapper due to factoring of the header files.
-    BOOL fIsPrebound = IsPrebound(image);
-    image->SavePrecode(this, 
-        pMD, 
-        t,  
-        GetPrecodeItemKind(image, pMD, fIsPrebound),
-        fIsPrebound);
-#else
-    _ASSERTE(FitsIn<ULONG>(SizeOf(t)));
-    image->StoreStructure((void*)GetStart(), 
-        static_cast<ULONG>(SizeOf(t)), 
-        GetPrecodeItemKind(image, pMD, IsPrebound(image)),
-        AlignOf(t));
-#endif // _TARGET_X86_ || _TARGET_AMD64_
-}
-
 void Precode::Fixup(DataImage *image, MethodDesc * pMD)
 {
     STANDARD_VM_CONTRACT;

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -99,12 +99,6 @@ private:
         return dac_cast<TADDR>(this);
     }
 
-    // Determines if the precode is part of a native image
-    BOOL IsZapped();
-    // Determines if the precode is part of a native image
-    // Optimization if the caller already has the precode's MethodDesc available.
-    BOOL IsZapped(PTR_MethodDesc pMD);
-
 #ifdef FEATURE_PREJIT
     BOOL SetZappedTargetInterlocked(PTR_MethodDesc pMD, PCODE pTarget, PCODE pExpected);
 #endif
@@ -265,6 +259,12 @@ public:
 
     MethodDesc *  GetMethodDesc(BOOL fSpeculative = FALSE);
     BOOL          IsCorrectMethodDesc(MethodDesc *  pMD);
+
+    // Determines if the precode is part of a native image
+    BOOL IsZapped();
+    // Determines if the precode is part of a native image
+    // Optimization if the caller already has the precode's MethodDesc available.
+    BOOL IsZapped(PTR_MethodDesc pMD);
 
     static Precode* Allocate(PrecodeType t, MethodDesc* pMD,
         LoaderAllocator *pLoaderAllocator, AllocMemTracker *pamTracker);

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -340,11 +340,13 @@ public:
     class SaveChunk
     {
         // Array of methods to be saved in the method desc chunk
-        InlineSArray<MethodDesc *, 20> m_rgPendingChunk;
+        InlineSArray<MethodDesc *, 20> m_rgMethods;
+        // Array of bools for methods for which we should register the precode as a surrogate
+        InlineSArray<BOOL, 20> m_rgRegisterSurrogateFlags;
 
     public:
         // Add method desc to the list of MDs to save in the chunk
-        void AddPrecodeForMethod(MethodDesc * pMD);
+        void AddPrecodeForMethod(MethodDesc * pMD, BOOL registerSurrogate);
 
         // Save the entire chunk. The method returns pointer to the saved chunk.
         // This pointer is registered in the image and can be used with Fixup infra.

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -339,14 +339,16 @@ public:
     // Helper class for saving precodes in chunks
     class SaveChunk
     {
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
         // Array of methods to be saved in the method desc chunk
         InlineSArray<MethodDesc *, 20> m_rgPendingChunk;
-#endif // HAS_FIXUP_PRECODE_CHUNKS
 
     public:
-        void Save(DataImage * image, MethodDesc * pMD);
-        void Flush(DataImage * image);
+        // Add method desc to the list of MDs to save in the chunk
+        void AddPrecodeForMethod(MethodDesc * pMD);
+
+        // Save the entire chunk. The method returns pointer to the saved chunk.
+        // This pointer is registered in the image and can be used with Fixup infra.
+        PVOID Save(DataImage * image);
     };
 #endif // FEATURE_PREJIT
 

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -331,7 +331,6 @@ public:
     // NGEN stuff
     // 
 
-    void Save(DataImage *image);
     void Fixup(DataImage *image, MethodDesc * pMD);
 
     BOOL IsPrebound(DataImage *image);

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -99,16 +99,11 @@ private:
         return dac_cast<TADDR>(this);
     }
 
-    BOOL IsZapped()
-    {
-        return IsZapped((PTR_MethodDesc)GetMethodDesc());
-    }
-
-    BOOL IsZapped(PTR_MethodDesc pMD)
-    {
-        Module * pZapModule = pMD->GetZapModule();
-        return (pZapModule != NULL) && pZapModule->IsZappedPrecode((PCODE)this);
-    }
+    // Determines if the precode is part of a native image
+    BOOL IsZapped();
+    // Determines if the precode is part of a native image
+    // Optimization if the caller already has the precode's MethodDesc available.
+    BOOL IsZapped(PTR_MethodDesc pMD);
 
 #ifdef FEATURE_PREJIT
     BOOL SetZappedTargetInterlocked(PTR_MethodDesc pMD, PCODE pTarget, PCODE pExpected);

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -99,6 +99,21 @@ private:
         return dac_cast<TADDR>(this);
     }
 
+    BOOL IsZapped()
+    {
+        return IsZapped((PTR_MethodDesc)GetMethodDesc());
+    }
+
+    BOOL IsZapped(PTR_MethodDesc pMD)
+    {
+        Module * pZapModule = pMD->GetZapModule();
+        return (pZapModule != NULL) && pZapModule->IsZappedPrecode((PCODE)this);
+    }
+
+#ifdef FEATURE_PREJIT
+    BOOL SetZappedTargetInterlocked(PTR_MethodDesc pMD, PCODE pTarget, PCODE pExpected);
+#endif
+
     static void UnexpectedPrecodeType(const char * originator, PrecodeType precodeType)
 
     {

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -262,9 +262,6 @@ public:
 
     // Determines if the precode is part of a native image
     BOOL IsZapped();
-    // Determines if the precode is part of a native image
-    // Optimization if the caller already has the precode's MethodDesc available.
-    BOOL IsZapped(PTR_MethodDesc pMD);
 
     static Precode* Allocate(PrecodeType t, MethodDesc* pMD,
         LoaderAllocator *pLoaderAllocator, AllocMemTracker *pamTracker);

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -99,10 +99,6 @@ private:
         return dac_cast<TADDR>(this);
     }
 
-#ifdef FEATURE_PREJIT
-    BOOL SetZappedTargetInterlocked(PTR_MethodDesc pMD, PCODE pTarget, PCODE pExpected);
-#endif
-
     static void UnexpectedPrecodeType(const char * originator, PrecodeType precodeType)
 
     {

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1723,6 +1723,15 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
     {
         pCode = GetStubForInteropMethod(this);
         
+        // Zapped methods can't patch the precodes, so they act as if they don't have one.
+        // Since for this to work, we need the precode (the pCode is a stub with methoddesc calling convention)
+        // we need to allocate one here.
+        // TODO: Backpatching - we probably need to patch all the possible slots this method lives in, not just the main one.
+        if (IsZapped() && !HasPrecode())
+        {
+            GetOrCreatePrecode();
+        }
+
         GetPrecode()->SetTargetInterlocked(pCode);
 
         RETURN GetStableEntryPoint();

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1723,16 +1723,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
     {
         pCode = GetStubForInteropMethod(this);
         
-        // Zapped methods can't patch the precodes, so they act as if they don't have one.
-        // Since for this to work, we need the precode (the pCode is a stub with methoddesc calling convention)
-        // we need to allocate one here.
-        // TODO: Backpatching - we probably need to patch all the possible slots this method lives in, not just the main one.
-        if (IsZapped() && !HasPrecode())
-        {
-            GetOrCreatePrecode();
-        }
-
-        GetPrecode()->SetTargetInterlocked(pCode);
+        GetOrCreatePrecode()->SetTargetInterlocked(pCode);
 
         RETURN GetStableEntryPoint();
     }

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1698,9 +1698,10 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
     // Zapped methods which need remoting precode are saved with normal temporary entry point
     // (so fixup or stub precode). So the first time we run into them here we need to create
     // the remoting precode for them and patch everywhere with it.
-    if (IsZapped() && GetPrecodeType() == PRECODE_REMOTING)
+    if (!HasStableEntryPoint() && GetPrecodeType() == PRECODE_REMOTING)
     {
         GetOrCreatePrecode();
+        _ASSERTE(HasStableEntryPoint());
 
         // Need to return here since we're intentionally leaving the precode pointing to prestub still
         // as actually resolving it could break things (in some cases remoting precode will never reach

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -79,7 +79,7 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, BO
     CONTRACTL_END;
     PCODE pTarget = GetStableEntryPoint();
 
-    BOOL hasTemporaryLikeEntryPoint = FALSE;
+    BOOL hasZappedPrecodeEntryPoint = FALSE;
 #ifdef FEATURE_PREJIT
     if (IsZapped() && pPreviousEntryPoint != NULL)
     {
@@ -89,11 +89,11 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, BO
         Module * pZapModule = GetZapModule();
         if ((pZapModule != NULL) && pZapModule->IsZappedPrecode(pPreviousEntryPoint))
         {
-            hasTemporaryLikeEntryPoint = TRUE;
+            hasZappedPrecodeEntryPoint = TRUE;
         }
     }
 #endif
-    if (!hasTemporaryLikeEntryPoint && !HasTemporaryEntryPoint())
+    if (!hasZappedPrecodeEntryPoint && !HasTemporaryEntryPoint())
         return pTarget;
 
     PCODE pExpected;
@@ -128,8 +128,11 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, BO
         }
 
 #ifndef HAS_COMPACT_ENTRYPOINTS
-        // Patch the fake entrypoint if necessary
-        Precode::GetPrecodeFromEntryPoint(pExpected)->SetTargetInterlocked(pTarget);
+        if (!hasZappedPrecodeEntryPoint)
+        {
+            // Patch the fake entrypoint if necessary
+            Precode::GetPrecodeFromEntryPoint(pExpected)->SetTargetInterlocked(pTarget);
+        }
 #endif // HAS_COMPACT_ENTRYPOINTS
     }
 

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -79,7 +79,6 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, BO
     CONTRACTL_END;
     PCODE pTarget = GetStableEntryPoint();
 
-    BOOL hasZappedPrecodeEntryPoint = FALSE;
     if (!HasTemporaryEntryPoint())
         return pTarget;
 
@@ -107,7 +106,9 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, BO
         }
 
 #ifndef HAS_COMPACT_ENTRYPOINTS
-        if (!hasZappedPrecodeEntryPoint)
+        // Zapped precodes can't be patched, so don't even try.
+        _ASSERTE(!IsZapped() || Precode::GetPrecodeFromEntryPoint(pExpected)->IsZapped());
+        if (!IsZapped())
         {
             // Patch the fake entrypoint if necessary
             Precode::GetPrecodeFromEntryPoint(pExpected)->SetTargetInterlocked(pTarget);

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -742,13 +742,13 @@ void ZapImage::ComputeRVAs()
 {
     ZapWriter::ComputeRVAs();
 
+    m_pInnerPtrs->Resolve();
+
     if (!IsReadyToRunCompilation())
     {
         m_pMethodSlots->Resolve();
         m_pWrappers->Resolve();
     }
-
-    m_pInnerPtrs->Resolve();
 
 #ifdef WIN64EXCEPTIONS
     SetRuntimeFunctionsDirectoryEntry();

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -343,6 +343,8 @@ void ZapImage::AllocateVirtualSections()
             m_pDelayLoadInfoTableSection[i] = NewVirtualSection(pDataSection, IBCProfiledSection | HotRange | DelayLoadInfoTableSection, sizeof(TADDR));
         }
 
+        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_VCHUNKS_AND_DICTIONARY] = NewVirtualSection(pDataSection, IBCProfiledSection | WarmRange | WriteableDataSection, sizeof(TADDR));
+
         m_pDynamicHelperCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodDataSection, sizeof(TADDR));
 
         m_pExternalMethodCellSection = NewVirtualSection(pDataSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodThunkSection, sizeof(TADDR));
@@ -416,16 +418,6 @@ void ZapImage::AllocateVirtualSections()
         // they are neither completely hot, nor completely cold. 
         m_pVirtualImportThunkSection        = NewVirtualSection(pXDataSection, IBCProfiledSection | HotColdSortedRange | VirtualImportThunkSection, HELPER_TABLE_ALIGN);
         m_pHelperTableSection               = NewVirtualSection(pXDataSection, IBCProfiledSection | HotColdSortedRange| HelperTableSection, HELPER_TABLE_ALIGN);
-
-        // hot for writing, i.e. profiling has indicated a write to this item, so at least one write likely per item at some point
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_WRITE] = NewVirtualSection(pXDataSection, IBCProfiledSection | HotRange | MethodPrecodeWriteSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_HOT] = NewVirtualSection(pXDataSection, IBCProfiledSection | HotRange | MethodPrecodeSection, sizeof(TADDR));
-
-        //
-        // cold sections
-        //
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD] = NewVirtualSection(pXDataSection, IBCProfiledSection | ColdRange | MethodPrecodeSection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD_WRITEABLE] = NewVirtualSection(pXDataSection, IBCProfiledSection | ColdRange | MethodPrecodeWriteableSection, sizeof(TADDR));
     }
 
     {
@@ -494,6 +486,16 @@ void ZapImage::AllocateVirtualSections()
 
         m_pStubsSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | StubsSection);
         m_pReadOnlyDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | ReadonlyDataSection);
+
+        // hot for writing, i.e. profiling has indicated a write to this item, so at least one write likely per item at some point
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_WRITE] = NewVirtualSection(pTextSection, IBCProfiledSection | HotRange | MethodPrecodeWriteSection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_HOT] = NewVirtualSection(pTextSection, IBCProfiledSection | HotRange | MethodPrecodeSection, sizeof(TADDR));
+
+        //
+        // cold sections
+        //
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD] = NewVirtualSection(pTextSection, IBCProfiledSection | ColdRange | MethodPrecodeSection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_METHOD_PRECODE_COLD_WRITEABLE] = NewVirtualSection(pTextSection, IBCProfiledSection | ColdRange | MethodPrecodeWriteableSection, sizeof(TADDR));
 
         m_pDynamicHelperDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodDataSection, sizeof(DWORD));
         m_pExternalMethodDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodDataSection, sizeof(DWORD));
@@ -573,7 +575,6 @@ void ZapImage::AllocateVirtualSections()
 #endif // defined(WIN64EXCEPTIONS)
 
         m_pPreloadSections[CORCOMPILE_SECTION_READONLY_WARM] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_VCHUNKS_AND_DICTIONARY] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, sizeof(TADDR));
 
         //
         // GC Info for methods which were not touched in profiling

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -117,8 +117,8 @@ ZapImage::~ZapImage()
     if (m_pInnerPtrs != NULL) 
         m_pInnerPtrs->~ZapInnerPtrTable();
 
-    if (m_pMethodEntryPoints != NULL)
-        m_pMethodEntryPoints->~ZapMethodEntryPointTable();
+    if (m_pMethodSlots != NULL)
+        m_pMethodSlots->~ZapMethodSlotTable();
 
     if (m_pWrappers != NULL) 
         m_pWrappers->~ZapWrapperTable();
@@ -185,7 +185,7 @@ void ZapImage::InitializeSections()
     // Initialization of auxiliary tables in alphabetical order
     //
     m_pInnerPtrs = new (GetHeap()) ZapInnerPtrTable(this);
-    m_pMethodEntryPoints = new (GetHeap()) ZapMethodEntryPointTable(this);
+    m_pMethodSlots = new (GetHeap()) ZapMethodSlotTable(this);
     m_pWrappers = new (GetHeap()) ZapWrapperTable(this);
 
     // Place the virtual sections tables in debug section. It exists for diagnostic purposes
@@ -663,7 +663,7 @@ void ZapImage::Preallocate()
     //
     m_pImportTable->Preallocate(cbILImage);
     m_pInnerPtrs->Preallocate(cbILImage);
-    m_pMethodEntryPoints->Preallocate(cbILImage);
+    m_pMethodSlots->Preallocate(cbILImage);
     m_pWrappers->Preallocate(cbILImage);
 
     if (m_pILMetaData != NULL)
@@ -744,7 +744,7 @@ void ZapImage::ComputeRVAs()
 
     if (!IsReadyToRunCompilation())
     {
-        m_pMethodEntryPoints->Resolve();
+        m_pMethodSlots->Resolve();
         m_pWrappers->Resolve();
     }
 

--- a/src/zap/zapimage.h
+++ b/src/zap/zapimage.h
@@ -24,7 +24,7 @@ class ZapCodeManagerEntry;
 class ZapReadyToRunHeader;
 
 class ZapInnerPtrTable;
-class ZapMethodEntryPointTable;
+class ZapMethodSlotTable;
 class ZapWrapperTable;
 
 class ZapBaseRelocs;
@@ -259,7 +259,7 @@ private:
 
     ZapInnerPtrTable *          m_pInnerPtrs;
 
-    ZapMethodEntryPointTable *  m_pMethodEntryPoints;
+    ZapMethodSlotTable *        m_pMethodSlots;
 
     ZapWrapperTable *           m_pWrappers;
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1854,7 +1854,9 @@ BOOL ZapInfo::embedDirectCall(CORINFO_METHOD_HANDLE ftn,
     if (moduleHandle == m_pImage->m_hModule 
         && m_pImage->m_pPreloader->CanEmbedMethodHandle(ftn, m_currentMethodHandle))
     {
-        pEntryPointOrThunkToEmbed = m_pImage->m_pMethodEntryPoints->GetMethodEntryPoint(ftn, accessFlags);
+        pResult->accessType = IAT_PVALUE;
+        pResult->addr = m_pImage->GetWrappers()->GetMethodSlot(ftn);
+        return TRUE;
     }
     else  // otherwise we are calling into an external module
     {

--- a/src/zap/zapinnerptr.h
+++ b/src/zap/zapinnerptr.h
@@ -31,6 +31,11 @@ public:
 
     virtual int GetOffset() = 0;
 
+    virtual DWORD GetSize()
+    {
+        return GetBase()->GetSize() - GetOffset();
+    }
+
     void Resolve()
     {
         if (m_pBase->IsPlaced())

--- a/src/zap/zapnodetype.h
+++ b/src/zap/zapnodetype.h
@@ -39,14 +39,13 @@ enum ZapNodeType {
 
 // PlaceHolders
 
-    ZapNodeType_MethodEntryPoint,
+    ZapNodeType_MethodSlot,
     ZapNodeType_ClassHandle,
     ZapNodeType_MethodHandle,
     ZapNodeType_FieldHandle,
     ZapNodeType_AddrOfPInvokeFixup,
     ZapNodeType_GenericHandle,
     ZapNodeType_ModuleIDHandle,
-    ZapNodeType_MethodSlot,
 
 // Code references
 

--- a/src/zap/zapnodetype.h
+++ b/src/zap/zapnodetype.h
@@ -46,6 +46,7 @@ enum ZapNodeType {
     ZapNodeType_AddrOfPInvokeFixup,
     ZapNodeType_GenericHandle,
     ZapNodeType_ModuleIDHandle,
+    ZapNodeType_MethodSlot,
 
 // Code references
 

--- a/src/zap/zapwrapper.cpp
+++ b/src/zap/zapwrapper.cpp
@@ -199,26 +199,3 @@ ZapNode * ZapWrapperTable::GetStub(void * pStub)
     _ASSERTE(pZapStub->GetType() == ZapNodeType_Stub);
     return m_pImage->GetInnerPtr(pZapStub, (PBYTE)pStub - (PBYTE)pStubData);
 }
-
-// Node which points to a method slot
-class ZapMethodSlot : public ZapWrapper
-{
-public:
-    virtual void Resolve(ZapImage * pImage)
-    {
-        SetRVA(pImage->m_pPreloader->MapMethodSlot(CORINFO_METHOD_HANDLE((BYTE *)GetHandle() - 2)));
-    }
-
-    virtual ZapNodeType GetType()
-    {
-        return ZapNodeType_MethodSlot;
-    }
-};
-
-ZapNode * ZapWrapperTable::GetMethodSlot(CORINFO_METHOD_HANDLE handle)
-{
-    // Disambiguate the normal method handle and address of P/Invoke fixup by adding 2
-    // The handle is effectively a pointer to the MD, so handle + 2 still fits into the size of the MD
-    // and can't run into a different method.
-    return GetPlaceHolder<ZapMethodSlot, ZapNodeType_MethodSlot>((BYTE *)handle + 2);
-}

--- a/src/zap/zapwrapper.cpp
+++ b/src/zap/zapwrapper.cpp
@@ -199,3 +199,23 @@ ZapNode * ZapWrapperTable::GetStub(void * pStub)
     _ASSERTE(pZapStub->GetType() == ZapNodeType_Stub);
     return m_pImage->GetInnerPtr(pZapStub, (PBYTE)pStub - (PBYTE)pStubData);
 }
+
+// Node which points to a method slot
+class ZapMethodSlot : public ZapWrapper
+{
+public:
+    virtual void Resolve(ZapImage * pImage)
+    {
+        SetRVA(pImage->m_pPreloader->MapMethodSlot(CORINFO_METHOD_HANDLE(GetHandle())));
+    }
+
+    virtual ZapNodeType GetType()
+    {
+        return ZapNodeType_MethodSlot;
+    }
+};
+
+ZapNode * ZapWrapperTable::GetMethodSlot(CORINFO_METHOD_HANDLE handle)
+{
+    return GetPlaceHolder<ZapMethodSlot, ZapNodeType_MethodSlot>(handle);
+}

--- a/src/zap/zapwrapper.cpp
+++ b/src/zap/zapwrapper.cpp
@@ -206,7 +206,7 @@ class ZapMethodSlot : public ZapWrapper
 public:
     virtual void Resolve(ZapImage * pImage)
     {
-        SetRVA(pImage->m_pPreloader->MapMethodSlot(CORINFO_METHOD_HANDLE(GetHandle())));
+        SetRVA(pImage->m_pPreloader->MapMethodSlot(CORINFO_METHOD_HANDLE((BYTE *)GetHandle() - 2)));
     }
 
     virtual ZapNodeType GetType()
@@ -217,5 +217,8 @@ public:
 
 ZapNode * ZapWrapperTable::GetMethodSlot(CORINFO_METHOD_HANDLE handle)
 {
-    return GetPlaceHolder<ZapMethodSlot, ZapNodeType_MethodSlot>(handle);
+    // Disambiguate the normal method handle and address of P/Invoke fixup by adding 2
+    // The handle is effectively a pointer to the MD, so handle + 2 still fits into the size of the MD
+    // and can't run into a different method.
+    return GetPlaceHolder<ZapMethodSlot, ZapNodeType_MethodSlot>((BYTE *)handle + 2);
 }

--- a/src/zap/zapwrapper.h
+++ b/src/zap/zapwrapper.h
@@ -133,7 +133,6 @@ public:
     ZapNode * GetAddrOfPInvokeFixup(CORINFO_METHOD_HANDLE handle);
     ZapNode * GetGenericHandle(CORINFO_GENERIC_HANDLE handle);
     ZapNode * GetModuleIDHandle(CORINFO_MODULE_HANDLE handle);
-    ZapNode * GetMethodSlot(CORINFO_METHOD_HANDLE handle);
 
     ZapNode * GetStub(void * pStub);
 

--- a/src/zap/zapwrapper.h
+++ b/src/zap/zapwrapper.h
@@ -133,6 +133,7 @@ public:
     ZapNode * GetAddrOfPInvokeFixup(CORINFO_METHOD_HANDLE handle);
     ZapNode * GetGenericHandle(CORINFO_GENERIC_HANDLE handle);
     ZapNode * GetModuleIDHandle(CORINFO_MODULE_HANDLE handle);
+    ZapNode * GetMethodSlot(CORINFO_METHOD_HANDLE handle);
 
     ZapNode * GetStub(void * pStub);
 


### PR DESCRIPTION
High-level changes:
- All calls within the same NGEN module go through indirection
- Method slots are used as the indirection cells
- Changes the slots to be writable and absolute pointers (both on MD and MT)
- Methods saved into native image are never marked as having a precode. If they don't have one, they are marked as stable entry point (as today). If they do have one, they are mark as not having a stable entry point. This behaves similarly to the method having a temporary entry point.
- Fixes around the fact that such native methods don't have the real temporary entry point - so special case these and use the "old" value of the slot as the temporary entry point (which points to the saved precode).

Passes most CoreCLR tests, some might still fail - work in progress.

Unsolved:
- Special methods (unboxing stubs, com interop) require creation of runtime allocated precodes at places where we don't normally backpatch all possible slots for the method. This means we might leave around code/slots which point to the saved precode which will never be patched. Slow since it would always go through prestub.

Future:
- Detect which methods need precodes at NGEN time and avoid indirection calls to those which don't. For now probably by "hacking" the callsite. Future - some methods can be decided up front, fixup only methods could be solved by branching in JIT.