### PR TITLE
Temporary entry points in ngen

### DIFF
--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -850,7 +850,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     // Set the actual chunk index
     FixupPrecode * pNewPrecode = (FixupPrecode *)image->GetImagePointer(this);
 
-    size_t mdOffset   = mdChunkOffset - sizeof(MethodDescChunk);
+    size_t mdOffset   = mdChunkOffset - MethodDescChunk::OffsetOfMethodDescsInSavedNode;
     size_t chunkIndex = mdOffset / MethodDesc::ALIGNMENT;
     _ASSERTE(FitsInU1(chunkIndex));
     pNewPrecode->m_MethodDescChunkIndex = (BYTE) chunkIndex;
@@ -859,7 +859,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     if (m_PrecodeChunkIndex == 0)
     {
         image->FixupFieldToNode(this, (BYTE *)GetBase() - (BYTE *)this,
-            pMDChunkNode, sizeof(MethodDescChunk));
+            pMDChunkNode, MethodDescChunk::OffsetOfMethodDescsInSavedNode);
     }
 }
 #endif // FEATURE_NATIVE_IMAGE_GENERATION

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -698,7 +698,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     // Set the actual chunk index
     FixupPrecode * pNewPrecode = (FixupPrecode *)image->GetImagePointer(this);
 
-    size_t mdOffset = mdChunkOffset - sizeof(MethodDescChunk);
+    size_t mdOffset = mdChunkOffset - MethodDescChunk::OffsetOfMethodDescsInSavedNode;
     size_t chunkIndex = mdOffset / MethodDesc::ALIGNMENT;
     _ASSERTE(FitsInU1(chunkIndex));
     pNewPrecode->m_MethodDescChunkIndex = (BYTE)chunkIndex;
@@ -707,7 +707,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     if (m_PrecodeChunkIndex == 0)
     {
         image->FixupFieldToNode(this, (BYTE *)GetBase() - (BYTE *)this,
-            pMDChunkNode, sizeof(MethodDescChunk));
+            pMDChunkNode, MethodDescChunk::OffsetOfMethodDescsInSavedNode);
     }
 }
 #endif // FEATURE_NATIVE_IMAGE_GENERATION

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3009,7 +3009,7 @@ void EEClass::Save(DataImage *image, MethodTable *pMT)
             methodDescSaveChunk.Append(pMD);
         }
 
-        ZapStoredStructure * pChunksNode = methodDescSaveChunk.Save();
+        ZapNode * pChunksNode = methodDescSaveChunk.Save();
         if (pChunksNode != NULL)    
             image->BindPointer(chunk, pChunksNode, 0);
 

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -3009,9 +3009,9 @@ void EEClass::Save(DataImage *image, MethodTable *pMT)
             methodDescSaveChunk.Append(pMD);
         }
 
-        ZapNode * pChunksNode = methodDescSaveChunk.Save();
+        ZapStoredStructure * pChunksNode = methodDescSaveChunk.Save();
         if (pChunksNode != NULL)    
-            image->BindPointer(chunk, pChunksNode, 0);
+            image->BindPointer(chunk, pChunksNode, MethodDescChunk::OffsetInSavedNode);
 
     }
 

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -25,7 +25,6 @@
 #include "../zap/zapwriter.h"
 #include "../zap/zapimage.h"
 #include "../zap/zapimport.h"
-#include "../zap/zapinnerptr.h"
 #include "inlinetracking.h"
 
 #define NodeTypeForItemKind(kind) ((ZapNodeType)(ZapNodeType_StoredStructure + kind))
@@ -288,11 +287,6 @@ void DataImage::CopyDataToOffset(ZapStoredStructure * pNode, ULONG offset, const
     memcpy((void *) target, p, size);
 }
 
-ZapNode * DataImage::GetInnerPtr(ZapNode * pNode, SSIZE_T offset)
-{
-    return m_pZapImage->GetInnerPtr(pNode, offset);
-}
-
 void DataImage::PlaceStructureForAddress(const void * data, CorCompileSection section)
 {
     STANDARD_VM_CONTRACT;
@@ -419,17 +413,6 @@ static SSIZE_T DecodeTargetOffset(PVOID pLocation, ZapRelocationType type)
     }
 }
 
-static void UnwrapInnerPtr(ZapNode ** ppNode, SSIZE_T * pOffset)
-{
-    ZapNode * pNode = *ppNode;
-    if (pNode->GetType() == ZapNodeType_InnerPtr)
-    {
-        ZapInnerPtr * pInnerPtr = (ZapInnerPtr *)pNode;
-        *ppNode = pInnerPtr->GetBase();
-        *pOffset += pInnerPtr->GetOffset();
-    }
-}
-
 void DataImage::FixupField(PVOID p, SSIZE_T offset, PVOID pTarget, SSIZE_T targetOffset, ZapRelocationType type)
 {
     STANDARD_VM_CONTRACT;
@@ -458,18 +441,14 @@ void DataImage::FixupField(PVOID p, SSIZE_T offset, PVOID pTarget, SSIZE_T targe
     targetOffset += pTargetEntry->offset;
     _ASSERTE(0 <= targetOffset && (DWORD)targetOffset <= pTargetEntry->pNode->GetSize());
 
-    SSIZE_T finalOffset = offset;
-    ZapNode * pNode = pEntry->pNode;
-    UnwrapInnerPtr(&pNode, &finalOffset);
-
     FixupEntry entry;
     entry.m_type = type;
-    entry.m_offset = (DWORD)finalOffset;
-    entry.m_pLocation = AsStoredStructure(pNode);
+    entry.m_offset = (DWORD)offset;
+    entry.m_pLocation = AsStoredStructure(pEntry->pNode);
     entry.m_pTargetNode = pTargetEntry->pNode;
     AppendFixup(entry);
 
-    EncodeTargetOffset((BYTE *)AsStoredStructure(pNode)->GetData() + finalOffset, targetOffset, type);
+    EncodeTargetOffset((BYTE *)AsStoredStructure(pEntry->pNode)->GetData() + offset, targetOffset, type);
 }
 
 void DataImage::FixupFieldToNode(PVOID p, SSIZE_T offset, ZapNode * pTarget, SSIZE_T targetOffset, ZapRelocationType type)
@@ -491,18 +470,14 @@ void DataImage::FixupFieldToNode(PVOID p, SSIZE_T offset, ZapNode * pTarget, SSI
 
     _ASSERTE(pTarget != NULL);
 
-    SSIZE_T finalOffset = offset;
-    ZapNode * pNode = pEntry->pNode;
-    UnwrapInnerPtr(&pNode, &finalOffset);
-
     FixupEntry entry;
     entry.m_type = type;
-    entry.m_offset = (DWORD)finalOffset;
-    entry.m_pLocation = AsStoredStructure(pNode);
+    entry.m_offset = (DWORD)offset;
+    entry.m_pLocation = AsStoredStructure(pEntry->pNode);
     entry.m_pTargetNode = pTarget;
     AppendFixup(entry);
 
-    EncodeTargetOffset((BYTE *)AsStoredStructure(pNode)->GetData() + finalOffset, targetOffset, type);
+    EncodeTargetOffset((BYTE *)AsStoredStructure(pEntry->pNode)->GetData() + offset, targetOffset, type);
 }
 
 DWORD DataImage::GetRVA(const void *data)
@@ -512,17 +487,7 @@ DWORD DataImage::GetRVA(const void *data)
     const StructureEntry * pEntry = m_structures.LookupPtr(data);
     _ASSERTE(pEntry != NULL);
 
-    ZapNode * pNode = pEntry->pNode;
-    SSIZE_T offset = pEntry->offset;
-
-    // Solve a problem with ordering of ComputeRVA.
-    // If there's a normal node which needs innerptr node's RVA it will likely fail
-    // since the innerptrs are resolved last.
-    // On the other hand, if the base of the innerptr is already resolved, then the innerptr's
-    // RVA can always be computed.
-    UnwrapInnerPtr(&pNode, &offset);
-
-    return pNode->GetRVA() + (DWORD)offset;
+    return pEntry->pNode->GetRVA() + (DWORD)pEntry->offset;
 }
 
 void DataImage::ZeroField(PVOID p, SSIZE_T offset, SIZE_T size)
@@ -552,11 +517,7 @@ void * DataImage::GetImagePointer(PVOID p, SSIZE_T offset)
     offset += pEntry->offset;
     _ASSERTE(0 <= offset && (DWORD)offset < pEntry->pNode->GetSize());
 
-    SSIZE_T finalOffset = offset;
-    ZapNode * pNode = pEntry->pNode;
-    UnwrapInnerPtr(&pNode, &finalOffset);
-
-    return (BYTE *)AsStoredStructure(pNode)->GetData() + finalOffset;
+    return (BYTE *)AsStoredStructure(pEntry->pNode)->GetData() + offset;
 }
 
 ZapNode * DataImage::GetNodeForStructure(PVOID p, SSIZE_T * pOffset)

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -470,7 +470,9 @@ public:
     ZapNode * GetGenericSignature(PVOID signature, BOOL fMethod);
 
     void SaveStubPrecodeChunk(TADDR ptr, SSIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind);
-    void SavePrecode(PVOID ptr, MethodDesc * pMD, PrecodeType t, ItemKind kind, BOOL fIsPrebound = FALSE);
+#ifdef HAS_NDIRECT_IMPORT_PRECODE
+    void SaveNDirectPrecode(PVOID ptr, MethodDesc * pMD, ItemKind kind);
+#endif // HAS_NDIRECT_IMPORT_PRECODE
 
     void StoreCompressedLayoutMap(LookupMapBase *pMap, ItemKind kind);
 

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -285,6 +285,12 @@ public:
     void CopyData(ZapStoredStructure * pNode, const void * p, ULONG size);
     void CopyDataToOffset(ZapStoredStructure * pNode, ULONG offset, const void * p, ULONG size);
 
+    ZapNode * GetInnerPtr(ZapNode * pNode, SSIZE_T offset);
+    ZapNode * GetInnerPtr(ZapStoredStructure * pNode, SSIZE_T offset)
+    {
+        return GetInnerPtr((ZapNode *)pNode, offset);
+    }
+
     //
     // In the second phase, data is arranged in the image by successive calls
     // to PlaceMappedRange.  Items are arranged using pointers to data structures in the

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -469,6 +469,7 @@ public:
 
     ZapNode * GetGenericSignature(PVOID signature, BOOL fMethod);
 
+    void SaveStubPrecodeChunk(TADDR ptr, SSIZE_T sizeOfOne, MethodDesc ** ppMD, COUNT_T count, ItemKind kind);
     void SavePrecode(PVOID ptr, MethodDesc * pMD, PrecodeType t, ItemKind kind, BOOL fIsPrebound = FALSE);
 
     void StoreCompressedLayoutMap(LookupMapBase *pMap, ItemKind kind);

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -285,12 +285,6 @@ public:
     void CopyData(ZapStoredStructure * pNode, const void * p, ULONG size);
     void CopyDataToOffset(ZapStoredStructure * pNode, ULONG offset, const void * p, ULONG size);
 
-    ZapNode * GetInnerPtr(ZapNode * pNode, SSIZE_T offset);
-    ZapNode * GetInnerPtr(ZapStoredStructure * pNode, SSIZE_T offset)
-    {
-        return GetInnerPtr((ZapNode *)pNode, offset);
-    }
-
     //
     // In the second phase, data is arranged in the image by successive calls
     // to PlaceMappedRange.  Items are arranged using pointers to data structures in the

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -6701,7 +6701,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     // Set the actual chunk index
     FixupPrecode * pNewPrecode = (FixupPrecode *)image->GetImagePointer(this);
 
-    size_t mdOffset   = mdChunkOffset - sizeof(MethodDescChunk);
+    size_t mdOffset   = mdChunkOffset - MethodDescChunk::OffsetOfMethodDescsInSavedNode;
     size_t chunkIndex = mdOffset / MethodDesc::ALIGNMENT;
     _ASSERTE(FitsInU1(chunkIndex));
     pNewPrecode->m_MethodDescChunkIndex = (BYTE) chunkIndex;
@@ -6710,7 +6710,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
     if (m_PrecodeChunkIndex == 0)
     {
         image->FixupFieldToNode(this, (BYTE *)GetBase() - (BYTE *)this,
-            pMDChunkNode, sizeof(MethodDescChunk));
+            pMDChunkNode, MethodDescChunk::OffsetOfMethodDescsInSavedNode);
     }
 }
 #endif // FEATURE_NATIVE_IMAGE_GENERATION

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -2702,7 +2702,7 @@ void MethodDesc::Save(DataImage *image)
         {
             // import thunk is only needed if the P/Invoke is inlinable
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)  
-            image->SavePrecode(pNMD->GetNDirectImportThunkGlue(), pNMD, PRECODE_NDIRECT_IMPORT, DataImage::ITEM_METHOD_PRECODE_COLD);
+            image->SaveNDirectPrecode(pNMD->GetNDirectImportThunkGlue(), pNMD, DataImage::ITEM_METHOD_PRECODE_COLD);
 #else
             image->StoreStructure(pNMD->GetNDirectImportThunkGlue(), sizeof(NDirectImportThunkGlue), DataImage::ITEM_METHOD_PRECODE_COLD);
 #endif

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -250,7 +250,7 @@ public:
         return GetMethodEntryPoint();
     }
 
-    BOOL SetStableEntryPointInterlocked(PCODE addr, PTR_PCODE ppPreviousEntryPoint = NULL);
+    BOOL SetStableEntryPointInterlocked(PCODE addr);
 
     BOOL HasTemporaryEntryPoint();
     PCODE GetTemporaryEntryPoint();
@@ -1635,13 +1635,11 @@ public:
     //     pDispatchingMT - method table of the object that the method is being dispatched on, can be NULL.
     //     fFullBackPatch - indicates whether to patch all possible slots, including the ones 
     //                      expensive to patch
-    //     pPreviousEntryPoint - if this is not NULL, the value is used as the expected value for all the patching
-    //                           that is slots with this value will be patched.
     //                      
     // Return value:
     //     stable entry point (code:MethodDesc::GetStableEntryPoint())
     //
-    PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch, PCODE pPreviousEntryPoint);
+    PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch);
 
     PCODE DoPrestub(MethodTable *pDispatchingMT);
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1966,15 +1966,20 @@ public:
     BOOL HasTemporaryEntryPoints()
     {
         LIMITED_METHOD_CONTRACT;
-        return !IsZapped();
+        return GetTemporaryEntryPoints() != NULL;
+    }
+
+    TADDR GetTemporaryEntryPointsSlot()
+    {
+        LIMITED_METHOD_CONTRACT;
+        _ASSERTE(sizeof(TADDR) == sizeof(TemporaryEntryPointsSlot));
+        return dac_cast<TADDR>(this) - sizeof(TADDR);
     }
 
     TADDR GetTemporaryEntryPoints()
     {
         LIMITED_METHOD_CONTRACT;
-        _ASSERTE(HasTemporaryEntryPoints());
-        _ASSERTE(sizeof(TADDR) == sizeof(TemporaryEntryPointsSlot));
-        TADDR pSlot = dac_cast<TADDR>(this) - sizeof(TADDR);
+        TADDR pSlot = GetTemporaryEntryPointsSlot();
         return IsZapped() ? TemporaryEntryPointsSlot::GetValueAtPtr(pSlot) : *PTR_TADDR(pSlot);
     }
 

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -1534,7 +1534,7 @@ public:
     {
         DataImage * m_pImage;
 
-        ZapNode * m_pFirstNode;
+        ZapStoredStructure * m_pFirstNode;
         MethodDescChunk * m_pLastChunk;
 
         typedef enum _MethodPriorityEnum
@@ -1575,7 +1575,7 @@ public:
 
         void Append(MethodDesc * pMD);
 
-        ZapNode * Save();
+        ZapStoredStructure * Save();
     };
 
     bool CanSkipDoPrestub(MethodDesc * callerMD, 
@@ -2132,6 +2132,11 @@ public:
     // The chunk is preceded by a temporary entry point slot.
     // For zapped chunks the slot is a relative pointer, for non-zapped it's a direct address.
     typedef RelativePointer<TADDR> TemporaryEntryPointsSlot;
+
+    // The offset of the MethodDescChunk structure in the node where it's saved (since it doesn't start at 0).
+    static const ULONG OffsetInSavedNode = sizeof(TemporaryEntryPointsSlot);
+    // The offset where the MethodDesc array starts in the saved node.
+    static const ULONG OffsetOfMethodDescsInSavedNode;
 
     // Maximum size of one chunk (corresponts to the maximum of m_size = 0xFF)
     static const SIZE_T MaxSizeOfMethodDescs = 0x100 * MethodDesc::ALIGNMENT;

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -796,31 +796,15 @@ BOOL Precode::IsPrebound(DataImage *image)
 #endif
 }
 
-void Precode::SaveChunk::Save(DataImage* image, MethodDesc * pMD)
+void Precode::SaveChunk::AddPrecodeForMethod(MethodDesc * pMD)
 {
     STANDARD_VM_CONTRACT;
 
-    PrecodeType precodeType = pMD->GetPrecodeType();
-
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
-    if (precodeType == PRECODE_FIXUP)
-    {
-        m_rgPendingChunk.Append(pMD);
-        return;
-    }
-#endif // HAS_FIXUP_PRECODE_CHUNKS
-
-    SIZE_T size = Precode::SizeOf(precodeType);
-    Precode* pPrecode = (Precode *)new (image->GetHeap()) BYTE[size];
-    pPrecode->Init(precodeType, pMD, NULL);
-    pPrecode->Save(image);
-
-    // Alias the temporary entrypoint
-    image->RegisterSurrogate(pMD, pPrecode);
+    m_rgPendingChunk.Append(pMD);
 }
 
 #ifdef HAS_FIXUP_PRECODE_CHUNKS
-static void SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T count, DataImage::ItemKind kind)
+static PVOID SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T count, DataImage::ItemKind kind)
 {
     STANDARD_VM_CONTRACT;
 
@@ -836,6 +820,7 @@ static void SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T
         FixupPrecode * pPrecode = pBase + i;
 
         pPrecode->InitForSave((count - 1) - i);
+        _ASSERTE((Precode *)pPrecode == Precode::GetPrecodeForTemporaryEntryPoint((TADDR)pBase, i));
 
         image->BindPointer(pPrecode, pNode, i * sizeof(FixupPrecode));
 
@@ -844,67 +829,69 @@ static void SaveFixupPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T
     }
 
     image->CopyData(pNode, pBase, size);
+
+    return pBase;
 }
 #endif // HAS_FIXUP_PRECODE_CHUNKS
 
-void Precode::SaveChunk::Flush(DataImage * image)
+static PVOID SaveStubPrecodeChunk(DataImage * image, MethodDesc ** rgMD, COUNT_T count, DataImage::ItemKind kind)
+{
+    ULONG sizeOfOne = Precode::SizeOfTemporaryEntryPoint(PRECODE_STUB);
+    ULONG size = sizeOfOne * count;
+    TADDR pBase = (TADDR)new (image->GetHeap()) BYTE[size];
+
+    for (COUNT_T i = 0; i < count; i++)
+    {
+        MethodDesc * pMD = rgMD[i];
+        StubPrecode * pPrecode = (StubPrecode *)(pBase + (sizeOfOne * i));
+
+        pPrecode->Init(pMD, NULL);
+        _ASSERTE((Precode *)pPrecode == Precode::GetPrecodeForTemporaryEntryPoint(pBase, i));
+
+        // Alias the temporary entrypoint
+        image->RegisterSurrogate(pMD, pPrecode);
+    }
+
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+    image->SaveStubPrecodeChunk(pBase, sizeOfOne, rgMD, count, kind);
+#else
+    ZapStoredStructure * pNode = image->StoreStructure(NULL, size, kind, PRECODE_ALIGNMENT);
+    for (COUNT_T i = 0; i < count; i++)
+    {
+        image->BindPointer((void *)(pBase + (sizeOfOne * i)), pNode, sizeOfOne * i);
+    }
+
+    image->CopyData(pNode, (void *)pBase, size);
+#endif // defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+
+    return (PVOID)pBase;
+}
+
+PVOID Precode::SaveChunk::Save(DataImage * image)
 {
     STANDARD_VM_CONTRACT;
 
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
+    // TODO: Since we have to save precodes in chunks defined by the MethodDescChunk
+    // and not by us here, the hot/cold splitting of precodes is not possible anymore
+    // Review the changes here and decide how to handle this - maybe we could apply the
+    // precode hot/cold split to method desc chunk ordering, or we will have to completely ignore it.
+    // For now we will save everything as cold - but that should probably change
+    // we should possibly apply the same hot/cold split as for methods themselves.
     if (m_rgPendingChunk.GetCount() == 0)
-        return;
+        return NULL;
 
-    // Sort MethodDescs using the item kind for hot-cold spliting
-    struct SortMethodDesc : CQuickSort< MethodDesc * >
-    {
-        DataImage * m_image;
-
-        SortMethodDesc(DataImage *image, MethodDesc **pBase, SSIZE_T iCount)
-            : CQuickSort< MethodDesc * >(pBase, iCount),
-            m_image(image)
-        {
-        }
-
-        int Compare(MethodDesc ** ppMD1, MethodDesc ** ppMD2)
-        {
-            MethodDesc * pMD1 = *ppMD1;
-            MethodDesc * pMD2 = *ppMD2;
-
-            // Compare item kind
-            DataImage::ItemKind kind1 = GetPrecodeItemKind(m_image, pMD1);
-            DataImage::ItemKind kind2 = GetPrecodeItemKind(m_image, pMD2);
-
-            return kind1 - kind2;
-        }
-    };
-
-    SortMethodDesc sort(image, &(m_rgPendingChunk[0]), m_rgPendingChunk.GetCount());
-    sort.Sort();
-
-    DataImage::ItemKind pendingKind = DataImage::ITEM_METHOD_PRECODE_COLD_WRITEABLE;
-    COUNT_T pendingCount = 0;
-
-    COUNT_T i;
-    for (i = 0; i < m_rgPendingChunk.GetCount(); i++)
-    {
-        MethodDesc * pMD = m_rgPendingChunk[i];
-
-        DataImage::ItemKind kind = GetPrecodeItemKind(image, pMD);
-        if (kind != pendingKind)
-        {
-            if (pendingCount != 0)
-                SaveFixupPrecodeChunk(image, &(m_rgPendingChunk[i-pendingCount]), pendingCount, pendingKind);
-
-            pendingKind = kind;
-            pendingCount = 0;
-        }
-
-        pendingCount++;
-    }
-
-    // Flush the remaining items
-    SaveFixupPrecodeChunk(image, &(m_rgPendingChunk[i-pendingCount]), pendingCount, pendingKind);
+    // The type of the precode used is simple.
+    // If we can, we will use Fixup precodes as those are more space efficient.
+    // If not we fallback to Stub precodes. We use the same precode type for all precodes in one chunk.
+    // There's no need to use precode which would be most suitable for the given method
+    // as the precodes saved here act as temporary entry points which will never be patched.
+    // Nobody should use the precode as a stable/multi-callable entry point for the method.
+    // We need the precode as the most simple way to get to the DoPrestub which will figure out
+    // what the method needs and potentially create a runtime allocated (patchable) precode of the right type.
+#ifdef HAS_FIXUP_PRECODE_CHUNKS
+    return SaveFixupPrecodeChunk(image, &m_rgPendingChunk[0], m_rgPendingChunk.GetCount(), DataImage::ItemKind::ITEM_METHOD_PRECODE_COLD);
+#else
+    return SaveStubPrecodeChunk(image, &m_rgPendingChunk[0], m_rgPendingChunk.GetCount(), DataImage::ItemKind::ITEM_METHOD_PRECODE_COLD);
 #endif // HAS_FIXUP_PRECODE_CHUNKS
 }
 

--- a/src/vm/precode.cpp
+++ b/src/vm/precode.cpp
@@ -700,36 +700,6 @@ static DataImage::ItemKind GetPrecodeItemKind(DataImage * image, MethodDesc * pM
     return kind;
 }
 
-void Precode::Save(DataImage *image)
-{
-    STANDARD_VM_CONTRACT;
-
-    MethodDesc * pMD = GetMethodDesc();
-    PrecodeType t = GetType();
-
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
-    _ASSERTE(GetType() != PRECODE_FIXUP);
-#endif
-
-#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
-    // StubPrecode and RemotingPrecode may have straddlers (relocations crossing pages) on x86 and x64. We need 
-    // to insert padding to eliminate it. To do that, we need to save these using custom ZapNode that can only
-    // be implemented in dataimage.cpp or zapper due to factoring of the header files.
-    BOOL fIsPrebound = IsPrebound(image);
-    image->SavePrecode(this, 
-        pMD, 
-        t,  
-        GetPrecodeItemKind(image, pMD, fIsPrebound),
-        fIsPrebound);
-#else
-    _ASSERTE(FitsIn<ULONG>(SizeOf(t)));
-    image->StoreStructure((void*)GetStart(), 
-        static_cast<ULONG>(SizeOf(t)), 
-        GetPrecodeItemKind(image, pMD, IsPrebound(image)),
-        AlignOf(t));
-#endif // _TARGET_X86_ || _TARGET_AMD64_
-}
-
 void Precode::Fixup(DataImage *image, MethodDesc * pMD)
 {
     STANDARD_VM_CONTRACT;

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -340,11 +340,13 @@ public:
     class SaveChunk
     {
         // Array of methods to be saved in the method desc chunk
-        InlineSArray<MethodDesc *, 20> m_rgPendingChunk;
+        InlineSArray<MethodDesc *, 20> m_rgMethods;
+        // Array of bools for methods for which we should register the precode as a surrogate
+        InlineSArray<BOOL, 20> m_rgRegisterSurrogateFlags;
 
     public:
         // Add method desc to the list of MDs to save in the chunk
-        void AddPrecodeForMethod(MethodDesc * pMD);
+        void AddPrecodeForMethod(MethodDesc * pMD, BOOL registerSurrogate);
 
         // Save the entire chunk. The method returns pointer to the saved chunk.
         // This pointer is registered in the image and can be used with Fixup infra.

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -339,14 +339,16 @@ public:
     // Helper class for saving precodes in chunks
     class SaveChunk
     {
-#ifdef HAS_FIXUP_PRECODE_CHUNKS
         // Array of methods to be saved in the method desc chunk
         InlineSArray<MethodDesc *, 20> m_rgPendingChunk;
-#endif // HAS_FIXUP_PRECODE_CHUNKS
 
     public:
-        void Save(DataImage * image, MethodDesc * pMD);
-        void Flush(DataImage * image);
+        // Add method desc to the list of MDs to save in the chunk
+        void AddPrecodeForMethod(MethodDesc * pMD);
+
+        // Save the entire chunk. The method returns pointer to the saved chunk.
+        // This pointer is registered in the image and can be used with Fixup infra.
+        PVOID Save(DataImage * image);
     };
 #endif // FEATURE_PREJIT
 

--- a/src/vm/precode.h
+++ b/src/vm/precode.h
@@ -331,7 +331,6 @@ public:
     // NGEN stuff
     // 
 
-    void Save(DataImage *image);
     void Fixup(DataImage *image, MethodDesc * pMD);
 
     BOOL IsPrebound(DataImage *image);

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -1698,9 +1698,10 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
     // Zapped methods which need remoting precode are saved with normal temporary entry point
     // (so fixup or stub precode). So the first time we run into them here we need to create
     // the remoting precode for them and patch everywhere with it.
-    if (IsZapped() && GetPrecodeType() == PRECODE_REMOTING)
+    if (!HasStableEntryPoint() && GetPrecodeType() == PRECODE_REMOTING)
     {
         GetOrCreatePrecode();
+        _ASSERTE(HasStableEntryPoint());
 
         // Need to return here since we're intentionally leaving the precode pointing to prestub still
         // as actually resolving it could break things (in some cases remoting precode will never reach

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -742,13 +742,13 @@ void ZapImage::ComputeRVAs()
 {
     ZapWriter::ComputeRVAs();
 
+    m_pInnerPtrs->Resolve();
+
     if (!IsReadyToRunCompilation())
     {
         m_pMethodSlots->Resolve();
         m_pWrappers->Resolve();
     }
-
-    m_pInnerPtrs->Resolve();
 
 #ifdef WIN64EXCEPTIONS
     SetRuntimeFunctionsDirectoryEntry();

--- a/src/zap/zapinnerptr.h
+++ b/src/zap/zapinnerptr.h
@@ -31,6 +31,11 @@ public:
 
     virtual int GetOffset() = 0;
 
+    virtual DWORD GetSize()
+    {
+        return GetBase()->GetSize() - GetOffset();
+    }
+
     void Resolve()
     {
         if (m_pBase->IsPlaced())


### PR DESCRIPTION
Doing this in a separate branch to make the PR easier to manage. Eventually this should be merged with the rest of the NGEN Precode work (as it's based on it).

- Save precodes as temporary entry points in NGEN images
- Only uses fixup/stub precodes as they can't be reused at runtime anyway
- Changes to zap structure tracking to allow for internal pointers to saved structures
- Save the pointer (relative) to the temporary entry points in front of the method desc chunk (just like runtime layout)
- Revert changes to method PreStub logic to basically behave just like for runtime temporary entry points with only very small differences.
- Remove code used to save precodes which are not used anymore in NGEN images
