### PR TITLE
Make VirtualImportThunk and runtime helper calls non-wx on x64

### DIFF
--- a/src/vm/amd64/cgenamd64.cpp
+++ b/src/vm/amd64/cgenamd64.cpp
@@ -836,8 +836,8 @@ BOOL DoesSlotCallPrestub(PCODE pCode)
 
 #ifdef FEATURE_PREJIT
         // NGEN helper
-        if (*PTR_BYTE(pCode) == X86_INSTR_JMP_REL32) {
-            pCode = (TADDR)rel32Decode(pCode+1);
+        if (*PTR_WORD(pCode) == X86_INSTR_JMP_IND) {
+            pCode = *PTR_TADDR((TADDR)rel32Decode(pCode+2));
         }
 #endif
 
@@ -860,8 +860,8 @@ BOOL DoesSlotCallPrestub(PCODE pCode)
 
 #ifdef FEATURE_PREJIT
     // NGEN helper
-    if (*PTR_BYTE(pCode) == X86_INSTR_JMP_REL32) {
-        pCode = (TADDR)rel32Decode(pCode+1);
+    if (*PTR_WORD(pCode) == X86_INSTR_JMP_IND) {
+        pCode = *PTR_TADDR((TADDR)rel32Decode(pCode+2));
     }
 #endif
 

--- a/src/vm/amd64/cgenamd64.cpp
+++ b/src/vm/amd64/cgenamd64.cpp
@@ -965,26 +965,7 @@ EXTERN_C PCODE VirtualMethodFixupWorker(TransitionBlock * pTransitionBlock, CORC
         _ASSERTE(!pMD->HasNonVtableSlot());
         _ASSERTE(!pMT->IsInterface());
         _ASSERTE(!pMD->IsStatic());
-        // pMD->SetStableEntryPointInterlocked(pCode);
         pMT->SetSlot(slotNumber, pCode);
-
-        // INT64 oldValue = *(INT64*)pThunk;
-        // BYTE* pOldValue = (BYTE*)&oldValue;
-        // 
-        // if (pOldValue[0] == X86_INSTR_CALL_REL32)
-        // {
-        //     INT64 newValue = oldValue;
-        //     BYTE* pNewValue = (BYTE*)&newValue;
-        //     pNewValue[0] = X86_INSTR_JMP_REL32;
-        // 
-        //     *(INT32 *)(pNewValue+1) = rel32UsingJumpStub((INT32*)(&pThunk->callJmp[1]), pCode, pMD, NULL);
-        // 
-        //     _ASSERTE(IS_ALIGNED(pThunk, sizeof(INT64)));
-        //     EnsureWritableExecutablePages(pThunk, sizeof(INT64));
-        //     FastInterlockCompareExchangeLong((INT64*)pThunk, newValue, oldValue);
-        // 
-        //     FlushInstructionCache(GetCurrentProcess(), pThunk, 8);
-        // }
         
         UNINSTALL_UNWIND_AND_CONTINUE_HANDLER_NO_PROBE;
         UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -776,7 +776,7 @@ void NDirectImportPrecode::Fixup(DataImage *image)
                       IMAGE_REL_BASED_PTR);
 
     image->FixupFieldToNode(this, offsetof(NDirectImportPrecode, m_pTarget),
-                            image->GetHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP),
+                            image->GetImportTable()->GetIndirectHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP),
                             0,
                             IMAGE_REL_BASED_PTR);
 }

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -1123,6 +1123,11 @@ ZapNode * DataImage::GetHelperThunk(CorInfoHelpFunc ftnNum)
     return m_pZapImage->GetHelperThunk(ftnNum);
 }
 
+ZapNode * DataImage::GetPlacedIndirectHelperThunk(CorInfoHelpFunc ftnNum)
+{
+    return m_pZapImage->GetImportTable()->GetPlacedIndirectHelperThunk(ftnNum);
+}
+
 ZapNode * DataImage::GetTypeHandleImport(TypeHandle th, PVOID pUniqueId)
 {
     ZapImport * pImport = m_pZapImage->GetImportTable()->GetClassHandleImport(CORINFO_CLASS_HANDLE(th.AsPtr()), pUniqueId);
@@ -1255,7 +1260,7 @@ public:
             pNode, (int)offset, IMAGE_REL_BASED_PTR);
 
         pImage->WriteReloc(&precode, offsetof(StubPrecode, m_rel32),
-            pImage->GetHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
+                           pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
 
         pZapWriter->Write(&precode, sizeof(precode));
     }
@@ -1284,7 +1289,7 @@ public:
             pNode, (int)offset, IMAGE_REL_BASED_PTR);
 
         pImage->WriteReloc(&precode, offsetof(StubPrecode, m_rel32),
-            pImage->GetHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP), 0, IMAGE_REL_BASED_REL32);
+                           pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP), 0, IMAGE_REL_BASED_REL32);
 
         pZapWriter->Write(&precode, sizeof(precode));
     }
@@ -1358,7 +1363,7 @@ public:
         else
         {
             pImage->WriteReloc(&precode, offsetof(RemotingPrecode, m_rel32),
-                pImage->GetHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
+                               pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
         }
 
         pZapWriter->Write(&precode, sizeof(precode));
@@ -1384,13 +1389,13 @@ void DataImage::SavePrecode(PVOID ptr, MethodDesc * pMD, PrecodeType t, ItemKind
     switch (t) {
     case PRECODE_STUB:
         pNode = new (GetHeap()) ZapStubPrecode(pMD, kind);
-        GetHelperThunk(CORINFO_HELP_EE_PRESTUB);
+        GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB);
         break;
 
 #ifdef HAS_NDIRECT_IMPORT_PRECODE
     case PRECODE_NDIRECT_IMPORT:
         pNode = new (GetHeap()) ZapNDirectImportPrecode(pMD, kind);
-        GetHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP);
+        GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP);
         break;
 #endif // HAS_NDIRECT_IMPORT_PRECODE
 
@@ -1402,7 +1407,7 @@ void DataImage::SavePrecode(PVOID ptr, MethodDesc * pMD, PrecodeType t, ItemKind
 
         if (!fIsPrebound)
         {
-            GetHelperThunk(CORINFO_HELP_EE_PRESTUB);
+            GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB);
         }
         break;
 #endif // HAS_REMOTING_PRECODE

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -1005,7 +1005,7 @@ void DataImage::FixupSectionPtr(SIZE_T offset, ZapNode * pNode)
 
 void DataImage::FixupJumpStubPtr(SIZE_T offset, CorInfoHelpFunc ftnNum)
 {
-    ZapNode * pNode = m_pZapImage->GetHelperThunkIfExists(ftnNum);
+    ZapNode * pNode = m_pZapImage->GetIndirectHelperThunkIfExists(ftnNum);
     if (pNode != NULL)
         FixupFieldToNode(m_module->m_pNGenLayoutInfo, offset, pNode);
 }

--- a/src/vm/dataimage.cpp
+++ b/src/vm/dataimage.cpp
@@ -1260,7 +1260,7 @@ public:
             pNode, (int)offset, IMAGE_REL_BASED_PTR);
 
         pImage->WriteReloc(&precode, offsetof(StubPrecode, m_rel32),
-                           pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
+            pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
 
         pZapWriter->Write(&precode, sizeof(precode));
     }
@@ -1289,7 +1289,7 @@ public:
             pNode, (int)offset, IMAGE_REL_BASED_PTR);
 
         pImage->WriteReloc(&precode, offsetof(StubPrecode, m_rel32),
-                           pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP), 0, IMAGE_REL_BASED_REL32);
+            pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PINVOKE_FIXUP), 0, IMAGE_REL_BASED_REL32);
 
         pZapWriter->Write(&precode, sizeof(precode));
     }
@@ -1363,7 +1363,7 @@ public:
         else
         {
             pImage->WriteReloc(&precode, offsetof(RemotingPrecode, m_rel32),
-                               pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
+                pImage->GetImportTable()->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRESTUB), 0, IMAGE_REL_BASED_REL32);
         }
 
         pZapWriter->Write(&precode, sizeof(precode));

--- a/src/vm/dataimage.h
+++ b/src/vm/dataimage.h
@@ -447,6 +447,7 @@ public:
     ZapNode * GetFixupList(MethodDesc * method);
 
     ZapNode * GetHelperThunk(CorInfoHelpFunc ftnNum);
+    ZapNode * GetPlacedIndirectHelperThunk(CorInfoHelpFunc ftnNum);
 
     // pUniqueId is used to allocate unique cells for cases where we cannot use the shared cell.
     ZapNode * GetTypeHandleImport(TypeHandle th, PVOID pUniqueId = NULL);

--- a/src/vm/i386/stublinkerx86.cpp
+++ b/src/vm/i386/stublinkerx86.cpp
@@ -6610,7 +6610,7 @@ void FixupPrecode::Fixup(DataImage *image, MethodDesc * pMD)
 
     SSIZE_T mdChunkOffset;
     ZapNode * pMDChunkNode = image->GetNodeForStructure(pMD, &mdChunkOffset);
-    ZapNode * pHelperThunk = image->GetHelperThunk(CORINFO_HELP_EE_PRECODE_FIXUP);
+    ZapNode * pHelperThunk = image->GetPlacedIndirectHelperThunk(CORINFO_HELP_EE_PRECODE_FIXUP);
 
     image->FixupFieldToNode(this, offsetof(FixupPrecode, m_rel32),
                             pHelperThunk, 0, IMAGE_REL_BASED_REL32);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -12972,7 +12972,7 @@ void Module::LoadHelperTable()
     if (tableSize == 0)
         return;
 
-    EnsureWritableExecutablePages(table, tableSize);
+    EnsureWritablePages(table, tableSize);
 
     BYTE * curEntry   = table;
     BYTE * tableEnd   = table + tableSize;

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -4850,6 +4850,8 @@ BOOL MethodDesc::SetStableEntryPointInterlocked(PCODE addr)
 
     PCODE pExpected = GetTemporaryEntryPoint();
     PTR_PCODE pSlot = GetAddrOfSlot();
+    // how can we get here if the vtvable slots aren't writeable?
+    _ASSERTE(HasNonVtableSlot());
     EnsureWritablePages(pSlot);
 
     BOOL fResult = FastInterlockCompareExchangePointer(pSlot, addr, pExpected) == pExpected;

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2341,10 +2341,6 @@ EXTERN_C PCODE VirtualMethodFixupWorker(Object * pThisPtr,  CORCOMPILE_VIRTUAL_I
         PCODE pDirectTarget = Precode::TryToSkipFixupPrecode(pCode);
         if (pDirectTarget != NULL) {
             pCode = pDirectTarget;
-            // I don't know how we could already have run precode and
-            // have it patched if we're hitting the virtual method
-            // fixup.
-            _ASSERTE(false);
         }
 
         // Patch the thunk to the actual method body

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2339,8 +2339,13 @@ EXTERN_C PCODE VirtualMethodFixupWorker(Object * pThisPtr,  CORCOMPILE_VIRTUAL_I
     {
         // Skip fixup precode jump for better perf
         PCODE pDirectTarget = Precode::TryToSkipFixupPrecode(pCode);
-        if (pDirectTarget != NULL)
+        if (pDirectTarget != NULL) {
             pCode = pDirectTarget;
+            // I don't know how we could already have run precode and
+            // have it patched if we're hitting the virtual method
+            // fixup.
+            _ASSERTE(false);
+        }
 
         // Patch the thunk to the actual method body
         if (EnsureWritableExecutablePagesNoThrow(&pThunk->m_pTarget, sizeof(pThunk->m_pTarget)))

--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -271,15 +271,15 @@ void ZapImage::OutputCode(CodeType codeType)
                         m_pExternalMethodDataTable->PlaceExternalMethodCell((ZapImport *)pTarget);
                     break;
 
+                case ZapNodeType_IndirectHelperThunk:
+                    if (!pTarget->IsPlaced())
+                        m_pImportTable->PlaceIndirectHelperThunk(pTarget);
+                    break;
+
 #ifdef FEATURE_READYTORUN_COMPILER
                 case ZapNodeType_DynamicHelperCell:
                     if (!pTarget->IsPlaced())
                         m_pDynamicHelperDataTable->PlaceDynamicHelperCell((ZapImport *)pTarget);
-                    break;
-
-                case ZapNodeType_IndirectHelperThunk:
-                    if (!pTarget->IsPlaced())
-                        m_pImportTable->PlaceIndirectHelperThunk(pTarget);
                     break;
 
                 case ZapNodeType_RVAFieldData:

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -332,6 +332,7 @@ void ZapImage::AllocateVirtualSections()
         m_pPreloadSections[CORCOMPILE_SECTION_RVA_STATICS_HOT] = NewVirtualSection(pDataSection, IBCProfiledSection | HotRange | RVAStaticsSection);
 
         m_pDelayLoadInfoTableSection[ZapImportSectionType_Eager] = NewVirtualSection(pDataSection, IBCUnProfiledSection | HotRange | DelayLoadInfoTableEagerSection, sizeof(TADDR));
+        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_VCHUNKS_AND_DICTIONARY] = NewVirtualSection(pDataSection, IBCProfiledSection | WarmRange | WriteableDataSection, sizeof(TADDR));
 
         //
         // Allocate dynamic info tables
@@ -414,7 +415,6 @@ void ZapImage::AllocateVirtualSections()
         // Some sections are placed in a sorted order. Hot items are placed first,
         // then cold items. These sections are marked as HotColdSortedRange since
         // they are neither completely hot, nor completely cold. 
-        m_pVirtualImportThunkSection        = NewVirtualSection(pXDataSection, IBCProfiledSection | HotColdSortedRange | VirtualImportThunkSection, HELPER_TABLE_ALIGN);
         m_pExternalMethodThunkSection       = NewVirtualSection(pXDataSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodThunkSection, HELPER_TABLE_ALIGN);
         m_pHelperTableSection               = NewVirtualSection(pXDataSection, IBCProfiledSection | HotColdSortedRange| HelperTableSection, HELPER_TABLE_ALIGN);
 
@@ -499,6 +499,7 @@ void ZapImage::AllocateVirtualSections()
         m_pDynamicHelperDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodDataSection, sizeof(DWORD));
         m_pExternalMethodDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | ExternalMethodDataSection, sizeof(DWORD));
         m_pStubDispatchDataSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | StubDispatchDataSection, sizeof(DWORD));
+        m_pVirtualImportThunkSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotColdSortedRange | VirtualImportThunkSection, HELPER_TABLE_ALIGN);
 
         m_pHotRuntimeFunctionLookupSection = NewVirtualSection(pTextSection, IBCProfiledSection | HotRange | RuntimeFunctionSection, sizeof(DWORD));
 #if !defined(WIN64EXCEPTIONS)
@@ -572,7 +573,6 @@ void ZapImage::AllocateVirtualSections()
 #endif // defined(WIN64EXCEPTIONS)
 
         m_pPreloadSections[CORCOMPILE_SECTION_READONLY_WARM] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, sizeof(TADDR));
-        m_pPreloadSections[CORCOMPILE_SECTION_READONLY_VCHUNKS_AND_DICTIONARY] = NewVirtualSection(pTextSection, IBCProfiledSection | WarmRange | ReadonlySection, sizeof(TADDR));
 
         //
         // GC Info for methods which were not touched in profiling

--- a/src/zap/zapimage.h
+++ b/src/zap/zapimage.h
@@ -186,7 +186,9 @@ public:
     ZapVirtualSection * m_pHeaderSection;
     ZapVirtualSection * m_pHelperTableSection;
     ZapVirtualSection * m_pLazyHelperSection;
+#ifdef FEATURE_READYTORUN_COMPILER
     ZapVirtualSection * m_pLazyMethodCallHelperSection;
+#endif
     ZapVirtualSection * m_pHotCodeSection;
     ZapVirtualSection * m_pHotGCSection;
     ZapVirtualSection * m_pHotTouchedGCSection;
@@ -815,6 +817,8 @@ public:
     {
         return m_pHelperThunks[ftnNum];
     }
+
+    ZapNode * GetIndirectHelperThunkIfExists(CorInfoHelpFunc ftnNum);
 
     ZapNode * GetHelperThunk(CorInfoHelpFunc ftnNum);
 

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -2263,7 +2263,7 @@ DWORD ZapIndirectHelperThunk::SaveWorker(ZapWriter * pZapWriter)
     *p++ = 0xFF;
     *p++ = 0x25;
     if (pImage != NULL)
-        pImage->WriteReloc(buffer, (int) (p - buffer), pImage->GetHelperThunk(GetHelper()), 0, IMAGE_REL_BASED_REL32);
+        pImage->WriteReloc(buffer, (int)(p - buffer), pImage->GetHelperThunk(GetHelper()), 0, IMAGE_REL_BASED_REL32);
     p += 4;
 #else
     PORTABILITY_ASSERT("ZapIndirectHelperThunk::SaveWorker");

--- a/src/zap/zapimport.h
+++ b/src/zap/zapimport.h
@@ -438,10 +438,12 @@ public:
 
     ZapImport * GetDictionaryLookupCell(CORCOMPILE_FIXUP_BLOB_KIND kind, CORINFO_RESOLVED_TOKEN * pResolvedToken, CORINFO_LOOKUP_KIND * pLookup);
 
+    ZapNode * GetIndirectHelperThunk(CorInfoHelpFunc helperNum);
+    void PlaceIndirectHelperThunk(ZapNode * pImport);
+    ZapNode * GetPlacedIndirectHelperThunk(CorInfoHelpFunc helperNum);
 #ifdef FEATURE_READYTORUN_COMPILER
     ZapNode * GetPlacedIndirectHelperThunk(ReadyToRunHelper helperNum, PVOID pArg = NULL, ZapNode * pCell = NULL);
     ZapNode * GetIndirectHelperThunk(ReadyToRunHelper helperNum, PVOID pArg = NULL);
-    void PlaceIndirectHelperThunk(ZapNode * pImport);
 
     ZapImport * GetPlacedHelperImport(ReadyToRunHelper helperNum);
     ZapImport * GetHelperImport(ReadyToRunHelper helperNum);

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1760,7 +1760,10 @@ void * ZapInfo::getHelperFtn (CorInfoHelpFunc ftnNum, void **ppIndirection)
         dwHelper |= CORCOMPILE_HELPER_PTR;
    break;
 #endif
+    case CORINFO_HELP_STRCNS_CURRENT_MODULE:
+        break;
     default:
+        dwHelper |= CORCOMPILE_HELPER_PTR;
         break;
     }
 


### PR DESCRIPTION
**First commit: Make VirtualImportThunk sections non-writeable.**

This changes the vtable slot section to be writeable, the
VirtualImportThunk section to be non-writeable, and the virtual fixup
worker to patch the methodtable slot instead of the thunk.

**Second commit: Use indirection cell for runtime helper calls**

This reuses ZapIndirectHelperThunk as the target of ngen'd helper
calls. The indirect helper thunk will jump to the runtime code through
the helper table, which is patched with indirection cells instead of
code, allowing it to be moved to the data section.

With these changes, I get a JIT assert in (JIT/Regression/JitBlue/GitHub_15237/GitHub_15237/GitHub_15237.sh), which I haven't investigated.