### PR TITLE
Implementation of ComponentDependencyResolver

### DIFF
--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -3652,4 +3652,10 @@
   <data name="Argument_PrecisionTooLarge" xml:space="preserve">
     <value>Precision cannot be larger than {0}.</value>
   </data>
+  <data name="ComponentDependencyResolver_FailedToLoadHostpolicy" xml:space="preserve">
+    <value>Cannot load hostpolicy library. ComponentDependencyResolver is currently only supported if the runtime is hosted through hostpolicy library.</value>
+  </data>
+  <data name="ComponentDependencyResolver_FailedToResolveDependencies" xml:space="preserve">
+    <value>Dependency resolution failed for component {0} with error code {1}.</value>
+  </data>
 </root>

--- a/src/System.Private.CoreLib/Resources/Strings.resx
+++ b/src/System.Private.CoreLib/Resources/Strings.resx
@@ -3656,6 +3656,6 @@
     <value>Cannot load hostpolicy library. ComponentDependencyResolver is currently only supported if the runtime is hosted through hostpolicy library.</value>
   </data>
   <data name="ComponentDependencyResolver_FailedToResolveDependencies" xml:space="preserve">
-    <value>Dependency resolution failed for component {0} with error code {1}.</value>
+    <value>Dependency resolution failed for component {0} with error code {1}. Detailed error: {2}</value>
   </data>
 </root>

--- a/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -304,6 +304,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\UnknownWrapper.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\VariantWrapper.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\Loader\AssemblyLoadContext.cs" />
+	<Compile Include="$(BclSourcesRoot)\System\Runtime\Loader\ComponentDependencyResolver.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\MemoryFailPoint.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\Serialization\FormatterServices.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\Versioning\CompatibilitySwitch.cs" />

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/ComponentDependencyResolver.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/ComponentDependencyResolver.cs
@@ -1,0 +1,283 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Internal.IO;
+
+namespace System.Runtime.Loader
+{
+    public sealed class ComponentDependencyResolver
+    {
+        /// <summary>
+        /// The name of the neutral culture (same value as in Variables::Init in CoreCLR)
+        /// </summary>
+        private const string NeutralCultureName = "neutral";
+
+        /// <summary>
+        /// The extension of resource assembly (same as in BindSatelliteResourceByResourceRoots in CoreCLR)
+        /// </summary>
+        private const string ResourceAssemblyExtension = ".dll";
+
+        private readonly string _componentAssemblyPath;
+        private readonly Dictionary<string, string> _assemblyPaths;
+        private readonly string[] _nativeSearchPaths;
+        private readonly string[] _resourceSearchPaths;
+        private readonly string[] _componentDirectorySearchPaths;
+
+        public ComponentDependencyResolver(string componentAssemblyPath)
+        {
+            _componentAssemblyPath = componentAssemblyPath;
+
+            string assemblyPathsList = null;
+            string nativeSearchPathsList = null;
+            string resourceSearchPathsList = null;
+            int returnCode = 0;
+
+            try
+            {
+                returnCode = corehost_resolve_component_dependencies(
+                    componentAssemblyPath,
+                    (assembly_paths, native_search_paths, resource_search_paths) =>
+                    {
+                        assemblyPathsList = assembly_paths;
+                        nativeSearchPathsList = native_search_paths;
+                        resourceSearchPathsList = resource_search_paths;
+                    });
+            }
+            catch (EntryPointNotFoundException entryPointNotFoundException)
+            {
+                throw new InvalidOperationException(SR.ComponentDependencyResolver_FailedToLoadHostpolicy, entryPointNotFoundException);
+            }
+            catch (DllNotFoundException dllNotFoundException)
+            {
+                throw new InvalidOperationException(SR.ComponentDependencyResolver_FailedToLoadHostpolicy, dllNotFoundException);
+            }
+
+            if (returnCode != 0)
+            {
+                // Something went wrong - report a failure
+                // TODO - once we have the ability to capture detailed error messages from the hostpolicy
+                // use it here to make the exception more actionable.
+                throw new InvalidOperationException(SR.Format(SR.ComponentDependencyResolver_FailedToResolveDependencies, componentAssemblyPath, returnCode));
+            }
+
+            string[] assemblyPaths = SplitPathsList(assemblyPathsList);
+
+            // Assembly simple names are case insensitive per the runtime behavior
+            // (see SimpleNameToFileNameMapTraits for the TPA lookup hash).
+            _assemblyPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string assemblyPath in assemblyPaths)
+            {
+                _assemblyPaths.Add(Path.GetFileNameWithoutExtension(assemblyPath), assemblyPath);
+            }
+
+            _nativeSearchPaths = SplitPathsList(nativeSearchPathsList);
+            _resourceSearchPaths = SplitPathsList(resourceSearchPathsList);
+
+            _componentDirectorySearchPaths = new string[1] { Path.GetDirectoryName(componentAssemblyPath) };
+        }
+
+        public string ResolveAssemblyPath(AssemblyName assemblyName)
+        {
+            // Determine if the assembly name is for a satellite assembly or not
+            // This is the same logic as in AssemblyBinder::BindByTpaList in CoreCLR
+            // - If the culture name is non-empty and it's not 'neutral' 
+            // - The culture name is the value of the AssemblyName.Culture.Name 
+            //     (CoreCLR gets this and stores it as the culture name in the internal assembly name)
+            //     AssemblyName.CultureName is just a shortcut to AssemblyName.Culture.Name.
+            if (!string.IsNullOrEmpty(assemblyName.CultureName) && 
+                !string.Equals(assemblyName.CultureName, "neutral", StringComparison.OrdinalIgnoreCase))
+            {
+                // Load satellite assembly
+                // Search resource search paths by appending the culture name and the expected assembly file name.
+                // Copies the logic in BindSatelliteResourceByResourceRoots in CoreCLR.
+                // Note that the runtime will also probe APP_PATHS the same way, but that feature is effectively 
+                // being deprecated, so we chose to not support the same behavior for components.
+                foreach (string searchPath in _resourceSearchPaths)
+                {
+                    string assemblyPath = Path.Combine(
+                        searchPath,
+                        assemblyName.CultureName,
+                        assemblyName.Name + ResourceAssemblyExtension);
+                    if (File.Exists(assemblyPath))
+                    {
+                        return assemblyPath;
+                    }
+                }
+            }
+            else
+            {
+                // Load code assembly - simply look it up in the dictionary by its simple name.
+                if (_assemblyPaths.TryGetValue(assemblyName.Name, out string assemblyPath))
+                {
+                    // Only returnd the assembly if it exists on disk - this is to make the behavior of the API
+                    // consistent. Resource and native resolutions will only return existing files
+                    // so assembly resolution should do the same.
+                    if (File.Exists(assemblyPath))
+                    {
+                        return assemblyPath;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public string ResolveUnmanagedDllPath(string unmanagedDllName)
+        {
+            string[] searchPaths;
+            if (unmanagedDllName.Contains(Path.DirectorySeparatorChar))
+            {
+                // Library names with absolute or relative path can't be resolved
+                // using the component .deps.json as that defines simple names.
+                // So instead use the component directory as the lookup path.
+                searchPaths = _componentDirectorySearchPaths;
+            }
+            else
+            {
+                searchPaths = _nativeSearchPaths;
+            }
+
+            bool isRelativePath = !Path.IsPathFullyQualified(unmanagedDllName);
+            foreach (LibraryNameVariation libraryNameVariation in DetermineLibraryNameVariations(unmanagedDllName, isRelativePath))
+            {
+                string libraryName = libraryNameVariation.Prefix + unmanagedDllName + libraryNameVariation.Suffix;
+                foreach (string searchPath in searchPaths)
+                {
+                    string libraryPath = Path.Combine(searchPath, libraryName);
+                    if (File.Exists(libraryPath))
+                    {
+                        return libraryPath;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static string[] SplitPathsList(string pathsList)
+        {
+            if (pathsList == null)
+            {
+                return Array.Empty<string>();
+            }
+            else
+            {
+                return pathsList.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+        }
+
+        private struct LibraryNameVariation
+        {
+            public string Prefix;
+            public string Suffix;
+
+            public LibraryNameVariation(string prefix, string suffix)
+            {
+                Prefix = prefix;
+                Suffix = suffix;
+            }
+        }
+
+#if PLATFORM_WINDOWS
+        private const CharSet HostpolicyCharSet = CharSet.Unicode;
+        private const string LibraryNamePrefix = "";
+        private const string LibraryNameSuffix = ".dll";
+
+        private IEnumerable<LibraryNameVariation> DetermineLibraryNameVariations(string libName, bool isRelativePath)
+        {
+            // This is a copy of the logic in DetermineLibNameVariations in dllimport.cpp in CoreCLR
+
+            yield return new LibraryNameVariation(string.Empty, string.Empty);
+
+            if (isRelativePath &&
+                !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
+                !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
+            }
+        }
+#else
+        private const CharSet HostpolicyCharSet = CharSet.Ansi;
+
+        private const string LibraryNamePrefix = "lib";
+#if PLATFORM_OSX
+        private const string LibraryNameSuffix = ".dylib";
+#else
+        private const string LibraryNameSuffix = ".so";
+#endif
+
+        private IEnumerable<LibraryNameVariation> DetermineLibraryNameVariations(string libName, bool isRelativePath)
+        {
+            // This is a copy of the logic in DetermineLibNameVariations in dllimport.cpp in CoreCLR
+
+        if (!isRelativePath)
+            {
+                yield return new LibraryNameVariation(string.Empty, string.Empty);
+            }
+            else
+            {
+                bool containsSuffix = false;
+                int indexOfSuffix = libName.IndexOf(LibraryNameSuffix);
+                if (indexOfSuffix >= 0)
+                {
+                    indexOfSuffix += LibraryNameSuffix.Length;
+                    containsSuffix = indexOfSuffix == libName.Length || libName[indexOfSuffix] == '.';
+                }
+
+                bool containsDelim = libName.Contains(Path.DirectorySeparatorChar);
+
+                if (containsSuffix)
+                {
+                    yield return new LibraryNameVariation(string.Empty, string.Empty);
+                    if (!containsDelim)
+                    {
+                        yield return new LibraryNameVariation(LibraryNamePrefix, string.Empty);
+                    }
+                    yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
+                    if (!containsDelim)
+                    {
+                        yield return new LibraryNameVariation(LibraryNamePrefix, LibraryNameSuffix);
+                    }
+                }
+                else
+                {
+                    yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
+                    if (!containsDelim)
+                    {
+                        yield return new LibraryNameVariation(LibraryNamePrefix, LibraryNameSuffix);
+                    }
+                    yield return new LibraryNameVariation(string.Empty, string.Empty);
+                    if (!containsDelim)
+                    {
+                        yield return new LibraryNameVariation(LibraryNamePrefix, string.Empty);
+                    }
+                }
+            }
+
+
+            yield return new LibraryNameVariation(string.Empty, string.Empty);
+
+            if (isRelativePath &&
+                !libName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) &&
+                !libName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return new LibraryNameVariation(string.Empty, LibraryNameSuffix);
+            }
+        }
+#endif
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = HostpolicyCharSet)]
+        internal delegate void corehost_resolve_component_dependencies_result_fn(
+            string assembly_paths,
+            string native_search_paths,
+            string resource_search_paths);
+
+#pragma warning disable BCL0015 // Disable Pinvoke analyzer errors.
+        [DllImport("hostpolicy", CharSet = HostpolicyCharSet)]
+        private static extern int corehost_resolve_component_dependencies(
+            string component_main_assembly_path,
+            corehost_resolve_component_dependencies_result_fn result);
+#pragma warning restore
+    }
+}

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/ComponentDependencyResolver.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/ComponentDependencyResolver.cs
@@ -211,7 +211,7 @@ namespace System.Runtime.Loader
         {
             // This is a copy of the logic in DetermineLibNameVariations in dllimport.cpp in CoreCLR
 
-        if (!isRelativePath)
+            if (!isRelativePath)
             {
                 yield return new LibraryNameVariation(string.Empty, string.Empty);
             }
@@ -254,7 +254,6 @@ namespace System.Runtime.Loader
                     }
                 }
             }
-
 
             yield return new LibraryNameVariation(string.Empty, string.Empty);
 

--- a/tests/dir.sdkbuild.props
+++ b/tests/dir.sdkbuild.props
@@ -10,7 +10,7 @@
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <Platform>AnyCPU</Platform>
+    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
    
     <!-- Force the CLI to allow us to target higher netcoreapp than it may know about -->
     <NETCoreAppMaximumVersion>99.0</NETCoreAppMaximumVersion>

--- a/tests/src/Loader/ComponentDependencyResolverTests/CMakeLists.txt
+++ b/tests/src/Loader/ComponentDependencyResolverTests/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.6)
+project (hostpolicy)
+
+set(SOURCES HostpolicyMock.cpp )
+add_library(hostpolicy SHARED ${SOURCES})
+
+install(TARGETS hostpolicy DESTINATION bin)

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolver.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolver.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Reflection;
+
+namespace ComponentDependencyResolverTests
+{
+    /// <summary>
+    /// Temporary until the actual public API gets propagated through CoreFX.
+    /// </summary>
+    public class ComponentDependencyResolver
+    {
+        private object _implementation;
+        private Type _implementationType;
+        private MethodInfo _resolveAssemblyPathInfo;
+        private MethodInfo _resolveUnmanagedDllPathInfo;
+
+        public ComponentDependencyResolver(string componentAssemblyPath)
+        {
+            _implementationType = typeof(object).Assembly.GetType("System.Runtime.Loader.ComponentDependencyResolver");
+            _resolveAssemblyPathInfo = _implementationType.GetMethod("ResolveAssemblyPath");
+            _resolveUnmanagedDllPathInfo = _implementationType.GetMethod("ResolveUnmanagedDllPath");
+
+            try
+            {
+                _implementation = Activator.CreateInstance(_implementationType, componentAssemblyPath);
+            }
+            catch (TargetInvocationException tie)
+            {
+                throw tie.InnerException;
+            }
+        }
+
+        public string ResolveAssemblyPath(System.Reflection.AssemblyName assemblyName)
+        {
+            try
+            {
+                return (string)_resolveAssemblyPathInfo.Invoke(_implementation, new object[] { assemblyName });
+            }
+            catch (TargetInvocationException tie)
+            {
+                throw tie.InnerException;
+            }
+        }
+
+        public string ResolveUnmanagedDllPath(string unmanagedDllName)
+        {
+            try
+            {
+                return (string)_resolveUnmanagedDllPathInfo.Invoke(_implementation, new object[] { unmanagedDllName });
+            }
+            catch (TargetInvocationException tie)
+            {
+                throw tie.InnerException;
+            }
+        }
+    }
+}

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolver.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolver.cs
@@ -29,7 +29,7 @@ namespace ComponentDependencyResolverTests
             }
         }
 
-        public string ResolveAssemblyPath(System.Reflection.AssemblyName assemblyName)
+        public string ResolveAssemblyPath(AssemblyName assemblyName)
         {
             try
             {

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.cs
@@ -1,0 +1,254 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace ComponentDependencyResolverTests
+{
+    class ComponentDependencyResolverTests : TestBase
+    {
+        string _componentDirectory;
+        string _componentAssemblyPath;
+
+        protected override void Initialize()
+        {
+            HostPolicyMock.Initialize(TestBasePath, CoreRoot);
+            _componentDirectory = Path.Combine(TestBasePath, $"TestComponent_{Guid.NewGuid().ToString().Substring(0, 8)}");
+            Directory.CreateDirectory(_componentDirectory);
+            _componentAssemblyPath = CreateMockAssembly("TestComponent.dll");
+        }
+
+        protected override void Cleanup()
+        {
+            if (Directory.Exists(_componentDirectory))
+            {
+                Directory.Delete(_componentDirectory, recursive: true);
+            }
+        }
+
+        public void TestComponentLoadFailure()
+        {
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                134,
+                "",
+                "",
+                ""))
+            {
+                string message = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                        Path.Combine(TestBasePath, _componentAssemblyPath));
+                }).Message;
+
+                Assert.Contains("134", message);
+            }
+        }
+
+        public void TestAssembly()
+        {
+            string assemblyDependencyPath = CreateMockAssembly("AssemblyDependency.dll");
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                assemblyDependencyPath,
+                "",
+                ""))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Equal(
+                    assemblyDependencyPath,
+                    resolver.ResolveAssemblyPath(new AssemblyName("AssemblyDependency")));
+            }
+        }
+
+        public void TestAssemblyWithNoRecord()
+        {
+            // If the reqest is for assembly which is not listed in .deps.json
+            // the resolver should return null.
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                "",
+                "",
+                ""))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Null(resolver.ResolveAssemblyPath(new AssemblyName("AssemblyWithNoRecord")));
+            }
+        }
+
+        public void TestAssemblyWithMissingFile()
+        {
+            // Even if the .deps.json can resolve the request, if the file is not present
+            // the resolution should still return null.
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                Path.Combine(_componentDirectory, "NonExistingAssembly.dll"),
+                "",
+                ""))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Null(resolver.ResolveAssemblyPath(new AssemblyName("NonExistingAssembly")));
+            }
+        }
+
+        public void TestSingleResource()
+        {
+            string enResourcePath = CreateMockAssembly($"en{Path.DirectorySeparatorChar}TestComponent.resources.dll");
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                "",
+                "",
+                _componentDirectory))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Equal(
+                    enResourcePath,
+                    resolver.ResolveAssemblyPath(new AssemblyName("TestComponent.resources, Culture=en")));
+            }
+        }
+
+        public void TestMutipleResourcesWithSameBasePath()
+        {
+            string enResourcePath = CreateMockAssembly($"en{Path.DirectorySeparatorChar}TestComponent.resources.dll");
+            string csResourcePath = CreateMockAssembly($"cs{Path.DirectorySeparatorChar}TestComponent.resources.dll");
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                "",
+                "",
+                _componentDirectory))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Equal(
+                    enResourcePath,
+                    resolver.ResolveAssemblyPath(new AssemblyName("TestComponent.resources, Culture=en")));
+                Assert.Equal(
+                    csResourcePath,
+                    resolver.ResolveAssemblyPath(new AssemblyName("TestComponent.resources, Culture=cs")));
+            }
+        }
+
+        public void TestMutipleResourcesWithDifferentBasePath()
+        {
+            string enResourcePath = CreateMockAssembly($"en{Path.DirectorySeparatorChar}TestComponent.resources.dll");
+            string frResourcePath = CreateMockAssembly($"SubComponent{Path.DirectorySeparatorChar}fr{Path.DirectorySeparatorChar}TestComponent.resources.dll");
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                "",
+                "",
+                $"{_componentDirectory}{Path.PathSeparator}{Path.GetDirectoryName(Path.GetDirectoryName(frResourcePath))}"))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Equal(
+                    enResourcePath,
+                    resolver.ResolveAssemblyPath(new AssemblyName("TestComponent.resources, Culture=en")));
+                Assert.Equal(
+                    frResourcePath,
+                    resolver.ResolveAssemblyPath(new AssemblyName("TestComponent.resources, Culture=fr")));
+            }
+        }
+
+        public void TestAssemblyWithNeutralCulture()
+        {
+            string neutralAssemblyPath = CreateMockAssembly("NeutralAssembly.dll");
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                neutralAssemblyPath,
+                "",
+                ""))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Equal(
+                    neutralAssemblyPath,
+                    resolver.ResolveAssemblyPath(new AssemblyName("NeutralAssembly, Culture=neutral")));
+            }
+        }
+
+        public void TestSingleNativeDependency()
+        {
+            string nativeLibraryPath = CreateMockStandardNativeLibrary("native", "Single");
+
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                "",
+                Path.GetDirectoryName(nativeLibraryPath),
+                ""))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Equal(
+                    nativeLibraryPath,
+                    resolver.ResolveUnmanagedDllPath("Single"));
+            }
+        }
+
+        public void TestMultipleNativeDependencies()
+        {
+            string oneNativeLibraryPath = CreateMockStandardNativeLibrary($"native{Path.DirectorySeparatorChar}one", "One");
+            string twoNativeLibraryPath = CreateMockStandardNativeLibrary($"native{Path.DirectorySeparatorChar}two", "Two");
+
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                "",
+                $"{Path.GetDirectoryName(oneNativeLibraryPath)}{Path.PathSeparator}{Path.GetDirectoryName(twoNativeLibraryPath)}",
+                ""))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                Assert.Equal(
+                    oneNativeLibraryPath,
+                    resolver.ResolveUnmanagedDllPath("One"));
+                Assert.Equal(
+                    twoNativeLibraryPath,
+                    resolver.ResolveUnmanagedDllPath("Two"));
+            }
+        }
+
+        private string CreateMockAssembly(string relativePath)
+        {
+            string fullPath = Path.Combine(_componentDirectory, relativePath);
+            if (!File.Exists(fullPath))
+            {
+                string directory = Path.GetDirectoryName(fullPath);
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                File.WriteAllText(fullPath, "Mock assembly");
+            }
+
+            return fullPath;
+        }
+
+        private string CreateMockStandardNativeLibrary(string relativePath, string simpleName)
+        {
+            return CreateMockAssembly(
+                relativePath + Path.DirectorySeparatorChar + XPlatformUtils.GetStandardNativeLibraryFileName(simpleName));
+        }
+
+        public static int Main()
+        {
+            return TestBase.RunTests(
+                // It's important that the invalid hosting test runs first as it relies on the ability
+                // to delete (if it's there) the hostpolicy.dll. All other tests will end up loading the dll
+                // and thus locking it.
+                typeof(InvalidHostingTest),
+                typeof(ComponentDependencyResolverTests));
+        }
+    }
+}

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.cs
@@ -248,7 +248,8 @@ namespace ComponentDependencyResolverTests
                 // to delete (if it's there) the hostpolicy.dll. All other tests will end up loading the dll
                 // and thus locking it.
                 typeof(InvalidHostingTest),
-                typeof(ComponentDependencyResolverTests));
+                typeof(ComponentDependencyResolverTests),
+                typeof(NativeDependencyTests));
         }
     }
 }

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+    <Platform>$(__BuildArch)</Platform>
+    <ProjectGuid>{ABB86728-A3E0-4489-BD97-A0BAB00B322F}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants Condition="$(OSGroup) == 'Windows_NT'">WINDOWS</DefineConstants>
+    <DefineConstants Condition="$(OSGroup) == 'OSX'">OSX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ComponentDependencyResolver.cs" />
+    <Compile Include="ComponentDependencyResolverTests.cs" />
+    <Compile Include="HostPolicyMock.cs" />
+    <Compile Include="InvalidHostingTest.cs" />
+    <Compile Include="TestBase.cs" />
+    <Compile Include="XPlatformUtils.cs" />
+  </ItemGroup>
+  <!-- These are "hacks" to make the project build and launch from VS which makes it really easy to debug it. -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
+    <Platforms>x64</Platforms>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(CoreclrDir)/bin/tests/$(OSPlatformConfig)/Tests/Core_Root/CoreRun.exe</StartProgram>
+    <StartArguments>$(CoreclrDir)/bin/tests/$(OSPlatformConfig)/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests/ComponentDependencyResolverTests.exe</StartArguments>
+    <StartWorkingDirectory>$(CoreclrDir)/bin/tests/$(OSPlatformConfig)/Tests/Core_Root</StartWorkingDirectory>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
+    <Reference Include="$(TargetingPackPath)/*.dll">
+      <Private>false</Private>
+    </Reference>
+    <ProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
@@ -1,15 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
-  <PropertyGroup>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
-    <Platform>$(__BuildArch)</Platform>
     <ProjectGuid>{ABB86728-A3E0-4489-BD97-A0BAB00B322F}</ProjectGuid>
-  </PropertyGroup>
-  <PropertyGroup>
-    <DefineConstants Condition="$(OSGroup) == 'Windows_NT'">WINDOWS</DefineConstants>
-    <DefineConstants Condition="$(OSGroup) == 'OSX'">OSX</DefineConstants>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
   </PropertyGroup>
@@ -25,17 +23,5 @@
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
-  <!-- These are "hacks" to make the project build and launch from VS which makes it really easy to debug it. -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
-    <Platforms>x64</Platforms>
-    <StartAction>Program</StartAction>
-    <StartProgram>$(CoreclrDir)/bin/tests/$(OSPlatformConfig)/Tests/Core_Root/CoreRun.exe</StartProgram>
-    <StartArguments>$(CoreclrDir)/bin/tests/$(OSPlatformConfig)/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests/ComponentDependencyResolverTests.exe</StartArguments>
-    <StartWorkingDirectory>$(CoreclrDir)/bin/tests/$(OSPlatformConfig)/Tests/Core_Root</StartWorkingDirectory>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
-    <Reference Include="$(TargetingPackPath)/*.dll">
-      <Private>false</Private>
-    </Reference>
-  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
@@ -21,6 +21,11 @@
     <Compile Include="TestBase.cs" />
     <Compile Include="XPlatformUtils.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+
   <!-- These are "hacks" to make the project build and launch from VS which makes it really easy to debug it. -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
     <Platforms>x64</Platforms>
@@ -33,6 +38,5 @@
     <Reference Include="$(TargetingPackPath)/*.dll">
       <Private>false</Private>
     </Reference>
-    <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
@@ -18,14 +18,13 @@
     <Compile Include="ComponentDependencyResolverTests.cs" />
     <Compile Include="HostPolicyMock.cs" />
     <Compile Include="InvalidHostingTest.cs" />
+    <Compile Include="NativeDependencyTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="XPlatformUtils.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
-
   <!-- These are "hacks" to make the project build and launch from VS which makes it really easy to debug it. -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
     <Platforms>x64</Platforms>

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.csproj
@@ -9,6 +9,10 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants Condition="$(OSGroup) == 'Windows_NT'">WINDOWS</DefineConstants>
+    <DefineConstants Condition="$(OSGroup) == 'OSX'">OSX</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
   </PropertyGroup>
   <ItemGroup>

--- a/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.sln
+++ b/tests/src/Loader/ComponentDependencyResolverTests/ComponentDependencyResolverTests.sln
@@ -1,0 +1,55 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28301.50
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComponentDependencyResolverTests", "ComponentDependencyResolverTests.csproj", "{ABB86728-A3E0-4489-BD97-A0BAB00B322F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Checked|arm = Checked|arm
+		Checked|arm64 = Checked|arm64
+		Checked|x64 = Checked|x64
+		Checked|x86 = Checked|x86
+		Debug|arm = Debug|arm
+		Debug|arm64 = Debug|arm64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|arm = Release|arm
+		Release|arm64 = Release|arm64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|arm.ActiveCfg = Checked|arm
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|arm.Build.0 = Checked|arm
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|arm64.ActiveCfg = Checked|arm64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|arm64.Build.0 = Checked|arm64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|x64.ActiveCfg = Checked|x64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|x64.Build.0 = Checked|x64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|x86.ActiveCfg = Checked|x86
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Checked|x86.Build.0 = Checked|x86
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|arm.ActiveCfg = Debug|arm
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|arm.Build.0 = Debug|arm
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|arm64.ActiveCfg = Debug|arm64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|arm64.Build.0 = Debug|arm64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|x64.ActiveCfg = Debug|x64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|x64.Build.0 = Debug|x64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|x86.ActiveCfg = Debug|x86
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Debug|x86.Build.0 = Debug|x86
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|arm.ActiveCfg = Release|arm
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|arm.Build.0 = Release|arm
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|arm64.ActiveCfg = Release|arm64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|arm64.Build.0 = Release|arm64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|x64.ActiveCfg = Release|x64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|x64.Build.0 = Release|x64
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|x86.ActiveCfg = Release|x86
+		{ABB86728-A3E0-4489-BD97-A0BAB00B322F}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C7124802-399D-444B-9EA7-861354C574A7}
+	EndGlobalSection
+EndGlobal

--- a/tests/src/Loader/ComponentDependencyResolverTests/HostPolicyMock.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/HostPolicyMock.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace ComponentDependencyResolverTests
+{
+    class HostPolicyMock
+    {
+#if WINDOWS
+        private const CharSet HostpolicyCharSet = CharSet.Unicode;
+#else
+        private const CharSet HostpolicyCharSet = CharSet.Ansi;
+#endif
+
+        [DllImport("hostpolicy", CharSet = HostpolicyCharSet)]
+        private static extern int Set_corehost_resolve_component_dependencies_Values(
+            int returnValue,
+            string assemblyPaths,
+            string nativeSearchPaths,
+            string resourceSearchPaths);
+
+        public static string DeleteExistingHostpolicy(string coreRoot)
+        {
+            string hostPolicyFileName = XPlatformUtils.GetStandardNativeLibraryFileName("hostpolicy");
+            string destinationPath = Path.Combine(coreRoot, hostPolicyFileName);
+            if (File.Exists(destinationPath))
+            {
+                File.Delete(destinationPath);
+            }
+
+            return destinationPath;
+        }
+
+        public static void Initialize(string testBasePath, string coreRoot)
+        {
+            string hostPolicyFileName = XPlatformUtils.GetStandardNativeLibraryFileName("hostpolicy");
+            string destinationPath = DeleteExistingHostpolicy(coreRoot);
+
+            File.Copy(
+                Path.Combine(testBasePath, hostPolicyFileName),
+                destinationPath);
+        }
+
+        public static IDisposable Mock_corehost_resolve_componet_dependencies(
+            int returnValue,
+            string assemblyPaths,
+            string nativeSearchPaths,
+            string resourceSearchPaths)
+        {
+            Set_corehost_resolve_component_dependencies_Values(
+                returnValue,
+                assemblyPaths,
+                nativeSearchPaths,
+                resourceSearchPaths);
+
+            return new ResetMockValues_corehost_resolve_componet_dependencies();
+        }
+
+        private class ResetMockValues_corehost_resolve_componet_dependencies : IDisposable
+        {
+            public void Dispose()
+            {
+                Set_corehost_resolve_component_dependencies_Values(
+                    -1,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty);
+            }
+        }
+    }
+}

--- a/tests/src/Loader/ComponentDependencyResolverTests/HostpolicyMock.cpp
+++ b/tests/src/Loader/ComponentDependencyResolverTests/HostpolicyMock.cpp
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Mock implementation of the hostpolicy.cpp exported methods.
+// Used for testing CoreCLR/Corlib functionality which calls into hostpolicy.
+
+#include <string>
+
+// dllexport
+#if defined _WIN32
+
+#define DLL_EXPORT __declspec(dllexport)
+typedef wchar_t char_t;
+typedef std::wstring string_t;
+
+#else //!_Win32
+
+#if __GNUC__ >= 4
+#define DLL_EXPORT __attribute__ ((visibility ("default")))
+#else
+#define DLL_EXPORT
+#endif
+
+typedef char char_t;
+typedef std::string string_t;
+
+#endif //_WIN32
+
+int g_corehost_resolve_component_dependencies_returnValue = -1;
+string_t g_corehost_resolve_component_dependencies_assemblyPaths;
+string_t g_corehost_resolve_component_dependencies_nativeSearchPaths;
+string_t g_corehost_resolve_component_dependencies_resourceSearchPaths;
+
+typedef void(*corehost_resolve_component_dependencies_result_fn)(
+    const char_t* assembly_paths,
+    const char_t* native_search_paths,
+    const char_t* resource_search_paths);
+
+extern "C" DLL_EXPORT int corehost_resolve_component_dependencies(
+    const char_t *component_main_assembly_path,
+    corehost_resolve_component_dependencies_result_fn result)
+{
+    if (g_corehost_resolve_component_dependencies_returnValue == 0)
+    {
+        result(
+            g_corehost_resolve_component_dependencies_assemblyPaths.data(),
+            g_corehost_resolve_component_dependencies_nativeSearchPaths.data(),
+            g_corehost_resolve_component_dependencies_resourceSearchPaths.data());
+    }
+
+    return g_corehost_resolve_component_dependencies_returnValue;
+}
+
+extern "C" DLL_EXPORT void Set_corehost_resolve_component_dependencies_Values(
+    int returnValue,
+    const char_t *assemblyPaths,
+    const char_t *nativeSearchPaths,
+    const char_t *resourceSearchPaths)
+{
+    g_corehost_resolve_component_dependencies_returnValue = returnValue;
+    g_corehost_resolve_component_dependencies_assemblyPaths.assign(assemblyPaths);
+    g_corehost_resolve_component_dependencies_nativeSearchPaths.assign(nativeSearchPaths);
+    g_corehost_resolve_component_dependencies_resourceSearchPaths.assign(resourceSearchPaths);
+}

--- a/tests/src/Loader/ComponentDependencyResolverTests/InvalidHostingTest.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/InvalidHostingTest.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace ComponentDependencyResolverTests
+{
+    class InvalidHostingTest : TestBase
+    {
+        private string _componentDirectory;
+        private string _componentAssemblyPath;
+        private string _officialHostPolicyPath;
+        private string _localHostPolicyPath;
+        private string _renamedHostPolicyPath;
+
+        protected override void Initialize()
+        {
+            // Make sure there's no hostpolicy available
+            _officialHostPolicyPath = HostPolicyMock.DeleteExistingHostpolicy(CoreRoot);
+            string hostPolicyFileName = XPlatformUtils.GetStandardNativeLibraryFileName("hostpolicy");
+            _localHostPolicyPath = Path.Combine(TestBasePath, hostPolicyFileName);
+            _renamedHostPolicyPath = Path.Combine(TestBasePath, hostPolicyFileName + "_renamed");
+            File.Move(_localHostPolicyPath, _renamedHostPolicyPath);
+
+            _componentDirectory = Path.Combine(TestBasePath, $"InvalidHostingComponent_{Guid.NewGuid().ToString().Substring(0, 8)}");
+            Directory.CreateDirectory(_componentDirectory);
+            _componentAssemblyPath = Path.Combine(_componentDirectory, "InvalidHostingComponent.dll");
+            File.WriteAllText(_componentAssemblyPath, "Mock assembly");
+        }
+
+        protected override void Cleanup()
+        {
+            if (File.Exists(_renamedHostPolicyPath))
+            {
+                File.Move(_renamedHostPolicyPath, _localHostPolicyPath);
+            }
+        }
+
+        public void TestMissingHostPolicy()
+        {
+            object innerException = Assert.Throws<InvalidOperationException>(() =>
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+            }).InnerException;
+
+            Assert.IsType<DllNotFoundException>(innerException);
+        }
+
+        // Note: No good way to test the missing entry point case where hostpolicy.dll
+        // exists, but it doesn't have the right entry points.
+        // Loading a "wrong" hostpolicy.dll into the process is non-revertable operation
+        // so we would not be able to run other tests along side this one.
+        // Having a standalone .exe just for that one test is not worth it.
+    }
+}

--- a/tests/src/Loader/ComponentDependencyResolverTests/InvalidHostingTest.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/InvalidHostingTest.cs
@@ -19,6 +19,10 @@ namespace ComponentDependencyResolverTests
             string hostPolicyFileName = XPlatformUtils.GetStandardNativeLibraryFileName("hostpolicy");
             _localHostPolicyPath = Path.Combine(TestBasePath, hostPolicyFileName);
             _renamedHostPolicyPath = Path.Combine(TestBasePath, hostPolicyFileName + "_renamed");
+            if (File.Exists(_renamedHostPolicyPath))
+            {
+                File.Delete(_renamedHostPolicyPath);
+            }
             File.Move(_localHostPolicyPath, _renamedHostPolicyPath);
 
             _componentDirectory = Path.Combine(TestBasePath, $"InvalidHostingComponent_{Guid.NewGuid().ToString().Substring(0, 8)}");
@@ -29,6 +33,11 @@ namespace ComponentDependencyResolverTests
 
         protected override void Cleanup()
         {
+            if (Directory.Exists(_componentDirectory))
+            {
+                Directory.Delete(_componentDirectory, recursive: true);
+            }
+
             if (File.Exists(_renamedHostPolicyPath))
             {
                 File.Move(_renamedHostPolicyPath, _localHostPolicyPath);

--- a/tests/src/Loader/ComponentDependencyResolverTests/NativeDependencyTests.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/NativeDependencyTests.cs
@@ -1,0 +1,320 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace ComponentDependencyResolverTests
+{
+    class NativeDependencyTests : TestBase
+    {
+        string _componentDirectory;
+        string _componentAssemblyPath;
+
+        protected override void Initialize()
+        {
+            HostPolicyMock.Initialize(TestBasePath, CoreRoot);
+            _componentDirectory = Path.Combine(TestBasePath, $"TestComponent_{Guid.NewGuid().ToString().Substring(0, 8)}");
+
+            Directory.CreateDirectory(_componentDirectory);
+            _componentAssemblyPath = CreateMockFile("TestComponent.dll");
+        }
+
+        protected override void Cleanup()
+        {
+            if (Directory.Exists(_componentDirectory))
+            {
+                Directory.Delete(_componentDirectory, recursive: true);
+            }
+        }
+
+        public void TestSimpleNameAndNoPrefixAndNoSuffix()
+        {
+            ValidateNativeLibraryResolutions("{0}", "{0}", OS.Windows | OS.OSX | OS.Linux);
+        }
+
+        public void TestSimpleNameAndNoPrefixAndSuffix()
+        {
+            ValidateNativeLibraryResolutions("{0}.dll", "{0}", OS.Windows);
+            ValidateNativeLibraryResolutions("{0}.dylib", "{0}", OS.OSX);
+            ValidateNativeLibraryResolutions("{0}.so", "{0}", OS.Linux);
+        }
+
+        public void TestSimpleNameAndLibPrefixAndNoSuffix()
+        {
+            ValidateNativeLibraryResolutions("lib{0}", "{0}", OS.OSX | OS.Linux);
+        }
+
+        public void TestRelativeNameAndLibPrefixAndNoSuffix()
+        {
+            // The lib prefix is not added if the lookup is a relative path.
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}", "{0}", 0);
+        }
+
+        public void TestSimpleNameAndLibPrefixAndSuffix()
+        {
+            ValidateNativeLibraryResolutions("lib{0}.dll", "{0}", 0);
+            ValidateNativeLibraryResolutions("lib{0}.dylib", "{0}", OS.OSX);
+            ValidateNativeLibraryResolutions("lib{0}.so", "{0}", OS.Linux);
+        }
+
+        public void TestNameWithSuffixAndNoPrefixAndNoSuffix()
+        {
+            ValidateNativeLibraryResolutions("{0}", "{0}.dll", 0);
+            ValidateNativeLibraryResolutions("{0}", "{0}.dylib", 0);
+            ValidateNativeLibraryResolutions("{0}", "{0}.so", 0);
+        }
+
+        public void TestNameWithSuffixAndNoPrefixAndSuffix()
+        {
+            ValidateNativeLibraryResolutions("{0}.dll", "{0}.dll", OS.Windows | OS.OSX | OS.Linux);
+            ValidateNativeLibraryResolutions("{0}.dylib", "{0}.dylib", OS.Windows | OS.OSX | OS.Linux);
+            ValidateNativeLibraryResolutions("{0}.so", "{0}.so", OS.Windows | OS.OSX | OS.Linux);
+        }
+
+        public void TestNameWithSuffixAndNoPrefixAndDoubleSuffix()
+        {
+            // Unixes add the suffix even if one is already present.
+            ValidateNativeLibraryResolutions("{0}.dll.dll", "{0}.dll", 0);
+            ValidateNativeLibraryResolutions("{0}.dylib.dylib", "{0}.dylib", OS.OSX);
+            ValidateNativeLibraryResolutions("{0}.so.so", "{0}.so", OS.Linux);
+        }
+
+        public void TestNameWithSuffixAndPrefixAndNoSuffix()
+        {
+            ValidateNativeLibraryResolutions("lib{0}", "{0}.dll", 0);
+            ValidateNativeLibraryResolutions("lib{0}", "{0}.dylib", 0);
+            ValidateNativeLibraryResolutions("lib{0}", "{0}.so", 0);
+        }
+
+        public void TestNameWithSuffixAndPrefixAndSuffix()
+        {
+            ValidateNativeLibraryResolutions("lib{0}.dll", "{0}.dll", OS.OSX | OS.Linux);
+            ValidateNativeLibraryResolutions("lib{0}.dylib", "{0}.dylib", OS.OSX | OS.Linux);
+            ValidateNativeLibraryResolutions("lib{0}.so", "{0}.so", OS.OSX | OS.Linux);
+        }
+
+        public void TestRelativeNameWithSuffixAndPrefixAndSuffix()
+        {
+            // The lib prefix is not added if the lookup is a relative path
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.dll", "{0}.dll", 0);
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.dylib", "{0}.dylib", 0);
+            ValidateNativeLibraryWithRelativeLookupResolutions("lib{0}.so", "{0}.so", 0);
+        }
+
+        public void TestNameWithPrefixAndNoPrefixAndNoSuffix()
+        {
+            ValidateNativeLibraryResolutions("{0}", "lib{0}", 0);
+        }
+
+        public void TestNameWithPrefixAndPrefixAndNoSuffix()
+        {
+            ValidateNativeLibraryResolutions("lib{0}", "lib{0}", OS.Windows | OS.OSX | OS.Linux);
+        }
+
+        public void TestNameWithPrefixAndNoPrefixAndSuffix()
+        {
+            ValidateNativeLibraryResolutions("{0}.dll", "lib{0}", 0);
+            ValidateNativeLibraryResolutions("{0}.dylib", "lib{0}", 0);
+            ValidateNativeLibraryResolutions("{0}.so", "lib{0}", 0);
+        }
+
+        public void TestNameWithPrefixAndPrefixAndSuffix()
+        {
+            ValidateNativeLibraryResolutions("lib{0}.dll", "lib{0}", OS.Windows);
+            ValidateNativeLibraryResolutions("lib{0}.dylib", "lib{0}", OS.OSX);
+            ValidateNativeLibraryResolutions("lib{0}.so", "lib{0}", OS.Linux);
+        }
+
+        public void TestWindowsAddsSuffixEvenWithOnePresent()
+        {
+            ValidateNativeLibraryResolutions("{0}.ext.dll", "{0}.ext", OS.Windows);
+        }
+
+        public void TestWindowsDoesntAddSuffixWhenExectubaleIsPresent()
+        {
+            ValidateNativeLibraryResolutions("{0}.dll.dll", "{0}.dll", 0);
+            ValidateNativeLibraryResolutions("{0}.dll.exe", "{0}.dll", 0);
+            ValidateNativeLibraryResolutions("{0}.exe.dll", "{0}.exe", 0);
+            ValidateNativeLibraryResolutions("{0}.exe.exe", "{0}.exe", 0);
+        }
+
+        private void TestLookupWithSuffixPrefersUnmodifiedSuffixOnUnixes()
+        {
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.dylib", "lib{0}.dylib", "{0}.dylib", OS.OSX);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.so", "lib{0}.so", "{0}.so", OS.Linux);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.dylib", "{0}.dylib.dylib", "{0}.dylib", OS.OSX);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.so", "{0}.so.so", "{0}.so", OS.Linux);
+        }
+
+        private void TestLookupWithoutSuffixPrefersWithSuffixOnUnixes()
+        {
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.dylib", "lib{0}.dylib", "{0}", OS.OSX);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.so", "lib{0}.so", "{0}", OS.Linux);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.dylib", "{0}", "{0}", OS.OSX);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.so", "{0}", "{0}", OS.Linux);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.dylib", "lib{0}", "{0}", OS.OSX);
+            ValidateNativeLibraryResolutionsWithTwoFiles("{0}.so", "lib{0}", "{0}", OS.Linux);
+        }
+
+        public void TestFullPathLookupWithMatchingFileName()
+        {
+            ValidateFullPathNativeLibraryResolutions("{0}", "{0}", OS.Windows | OS.OSX | OS.Linux);
+            ValidateFullPathNativeLibraryResolutions("{0}.dll", "{0}.dll", OS.Windows | OS.OSX | OS.Linux);
+            ValidateFullPathNativeLibraryResolutions("{0}.dylib", "{0}.dylib", OS.Windows | OS.OSX | OS.Linux);
+            ValidateFullPathNativeLibraryResolutions("{0}.so", "{0}.so", OS.Windows | OS.OSX | OS.Linux);
+            ValidateFullPathNativeLibraryResolutions("lib{0}", "lib{0}", OS.Windows | OS.OSX | OS.Linux);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "lib{0}.dll", OS.Windows | OS.OSX | OS.Linux);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dylib", "lib{0}.dylib", OS.Windows | OS.OSX | OS.Linux);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.so", "lib{0}.so", OS.Windows | OS.OSX | OS.Linux);
+        }
+
+        public void TestFullPathLookupWithDifferentFileName()
+        {
+            ValidateFullPathNativeLibraryResolutions("lib{0}", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("{0}.dll", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("{0}.dylib", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("{0}.so", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dylib", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.so", "{0}", 0);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dll", "{0}.dll", 0);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.dylib", "{0}.dylib", 0);
+            ValidateFullPathNativeLibraryResolutions("lib{0}.so", "{0}.so", 0);
+        }
+
+        [Flags]
+        private enum OS
+        {
+            Windows = 0x1,
+            OSX = 0x2,
+            Linux = 0x4
+        }
+
+        private void ValidateNativeLibraryResolutions(
+            string fileNamePattern,
+            string lookupNamePattern,
+            OS resolvesOnOSes)
+        {
+            string newDirectory = Guid.NewGuid().ToString().Substring(0, 8);
+            string nativeLibraryPath = CreateMockFile(Path.Combine(newDirectory, string.Format(fileNamePattern, "NativeLibrary")));
+            ValidateNativeLibraryResolutions(
+                Path.GetDirectoryName(nativeLibraryPath),
+                nativeLibraryPath,
+                string.Format(lookupNamePattern, "NativeLibrary"),
+                resolvesOnOSes);
+        }
+
+        private void ValidateNativeLibraryWithRelativeLookupResolutions(
+            string fileNamePattern,
+            string lookupNamePattern,
+            OS resolvesOnOSes)
+        {
+            string newDirectory = Guid.NewGuid().ToString().Substring(0, 8);
+            string nativeLibraryPath = CreateMockFile(Path.Combine(newDirectory, string.Format(fileNamePattern, "NativeLibrary")));
+            ValidateNativeLibraryResolutions(
+                Path.GetDirectoryName(Path.GetDirectoryName(nativeLibraryPath)),
+                nativeLibraryPath,
+                Path.Combine(newDirectory, string.Format(lookupNamePattern, "NativeLibrary")),
+                resolvesOnOSes);
+        }
+
+        private void ValidateFullPathNativeLibraryResolutions(
+            string fileNamePattern,
+            string lookupNamePattern,
+            OS resolvesOnOSes)
+        {
+            string newDirectory = Guid.NewGuid().ToString().Substring(0, 8);
+            string nativeLibraryPath = CreateMockFile(Path.Combine(newDirectory, string.Format(fileNamePattern, "NativeLibrary")));
+            ValidateNativeLibraryResolutions(
+                Path.GetDirectoryName(nativeLibraryPath),
+                nativeLibraryPath,
+                Path.Combine(Path.GetDirectoryName(nativeLibraryPath), string.Format(lookupNamePattern, "NativeLibrary")),
+                resolvesOnOSes);
+        }
+
+        private void ValidateNativeLibraryResolutionsWithTwoFiles(
+            string fileNameToResolvePattern,
+            string otherFileNamePattern,
+            string lookupNamePattern,
+            OS resolvesOnOSes)
+        {
+            string newDirectory = Guid.NewGuid().ToString().Substring(0, 8);
+            string nativeLibraryPath = CreateMockFile(Path.Combine(newDirectory, string.Format(fileNameToResolvePattern, "NativeLibrary")));
+            CreateMockFile(Path.Combine(newDirectory, string.Format(otherFileNamePattern, "NativeLibrary")));
+            ValidateNativeLibraryResolutions(
+                Path.GetDirectoryName(nativeLibraryPath),
+                nativeLibraryPath,
+                string.Format(lookupNamePattern, "NativeLibrary"),
+                resolvesOnOSes);
+        }
+
+        private void ValidateNativeLibraryResolutions(
+            string nativeLibraryPaths,
+            string expectedResolvedFilePath,
+            string lookupName,
+            OS resolvesOnOSes)
+        {
+            using (HostPolicyMock.Mock_corehost_resolve_componet_dependencies(
+                0,
+                "",
+                $"{nativeLibraryPaths}",
+                ""))
+            {
+                ComponentDependencyResolver resolver = new ComponentDependencyResolver(
+                    Path.Combine(TestBasePath, _componentAssemblyPath));
+
+                string result = resolver.ResolveUnmanagedDllPath(lookupName);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    if (resolvesOnOSes.HasFlag(OS.Windows))
+                    {
+                        Assert.Equal(expectedResolvedFilePath, result);
+                    }
+                    else
+                    {
+                        Assert.Null(result);
+                    }
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    if (resolvesOnOSes.HasFlag(OS.OSX))
+                    {
+                        Assert.Equal(expectedResolvedFilePath, result);
+                    }
+                    else
+                    {
+                        Assert.Null(result);
+                    }
+                }
+                else
+                {
+                    if (resolvesOnOSes.HasFlag(OS.Linux))
+                    {
+                        Assert.Equal(expectedResolvedFilePath, result);
+                    }
+                    else
+                    {
+                        Assert.Null(result);
+                    }
+                }
+            }
+        }
+
+        private string CreateMockFile(string relativePath)
+        {
+            string fullPath = Path.Combine(_componentDirectory, relativePath);
+            if (!File.Exists(fullPath))
+            {
+                string directory = Path.GetDirectoryName(fullPath);
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                File.WriteAllText(fullPath, "Mock file");
+            }
+
+            return fullPath;
+        }
+    }
+}

--- a/tests/src/Loader/ComponentDependencyResolverTests/TestBase.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/TestBase.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace ComponentDependencyResolverTests
+{
+    class TestBase
+    {
+        protected string TestBasePath { get; private set; }
+        protected string BinaryBasePath { get; private set; }
+        protected string CoreRoot { get; private set; }
+
+        protected virtual void Initialize()
+        {
+        }
+
+        protected virtual void Cleanup()
+        {
+        }
+
+        public static int RunTests(params Type[] testTypes)
+        {
+            int result = 100;
+            foreach (Type testType in testTypes)
+            {
+                int testResult = RunTestsForType(testType);
+                if (testResult != 100)
+                {
+                    result = testResult;
+                }
+            }
+
+            return result;
+        }
+
+        private static int RunTestsForType(Type testType)
+        {
+            string testBasePath = Path.GetDirectoryName(testType.Assembly.Location);
+
+            TestBase runner = (TestBase)Activator.CreateInstance(testType);
+            runner.TestBasePath = testBasePath;
+            runner.BinaryBasePath = Path.GetDirectoryName(testBasePath);
+            runner.CoreRoot = GetCoreRoot();
+
+            try
+            {
+                runner.Initialize();
+
+                runner.RunTestsForInstance(runner);
+                return runner._retValue;
+            }
+            finally
+            {
+                runner.Cleanup();
+            }
+        }
+
+        private int _retValue = 100;
+        private void RunSingleTest(Action test, string testName = null)
+        {
+            testName = testName ?? test.Method.Name;
+
+            try
+            {
+                Console.WriteLine($"{testName} Start");
+                test();
+                Console.WriteLine($"{testName} PASSED.");
+            }
+            catch (Exception exe)
+            {
+                Console.WriteLine($"{testName} FAILED:");
+                Console.WriteLine(exe.ToString());
+                _retValue = -1;
+            }
+        }
+
+        private void RunTestsForInstance(object testClass)
+        {
+            foreach (MethodInfo m in testClass.GetType()
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .Where(m => m.Name.StartsWith("Test") && m.GetParameters().Length == 0))
+            {
+                RunSingleTest(() => m.Invoke(testClass, new object[0]), m.Name);
+            }
+        }
+
+        private static string GetCoreRoot()
+        {
+            string value = Environment.GetEnvironmentVariable("CORE_ROOT");
+            if (value == null)
+            {
+                value = Directory.GetCurrentDirectory();
+            }
+
+            return value;
+        }
+    }
+}

--- a/tests/src/Loader/ComponentDependencyResolverTests/XPlatformUtils.cs
+++ b/tests/src/Loader/ComponentDependencyResolverTests/XPlatformUtils.cs
@@ -1,0 +1,22 @@
+﻿namespace ComponentDependencyResolverTests
+{
+    class XPlatformUtils
+    {
+#if WINDOWS
+        public const string NativeLibraryPrefix = "";
+        public const string NativeLibrarySuffix = ".dll";
+#else
+        public const string NativeLibraryPrefix = "lib";
+#if OSX
+        public const string NativeLibrarySuffix = ".dylib";
+#else
+        public const string NativeLibrarySuffix = ".so";
+#endif
+#endif
+
+        public static string GetStandardNativeLibraryFileName(string simpleName)
+        {
+            return NativeLibraryPrefix + simpleName + NativeLibrarySuffix;
+        }
+    }
+}


### PR DESCRIPTION
PInvokes into hostpolicy.dll (which should live next to the runtime and thus always be reachable).
If the PInvoke fails (missing hostpolicy.dll) we will fail for now.

Adds tests for the API into CoreCLR repo. The main reason is that with corerun
we can easily mock the hostpolicy.dll since there's none to start with.
Writing the same tests in CoreFX or any other place which starts the runtime through
hostpolicy would require test-only functionality to exist in either the class itself
or in the hostpolicy.